### PR TITLE
feat: New consumer-focused landing page with Cata branding

### DIFF
--- a/BRAND.md
+++ b/BRAND.md
@@ -1,0 +1,345 @@
+# Cata Brand Guidelines
+
+**Status**: Work in Progress
+**Last Updated**: January 21, 2026
+
+---
+
+## Brand Identity
+
+### Name
+**Cata** (pronounced: CAH-tah)
+
+Spanish word for "tasting" (as in *cata de vinos* - wine tasting). Named as a nod to the founders' visit to a vineyard in Spain years before they had any interest in wine - the moment that planted the seed.
+
+### Tagline
+*TBD - Candidates:*
+- "Your wine, understood"
+- "Taste with confidence"
+- "Wine made personal"
+
+### What Cata Is
+A wine tasting app that makes wine approachable through technology. Your personal sommelier in your pocket - it knows your taste, suggests wines you'll love, and makes learning about wine feel like play.
+
+### What Cata Is Not
+- Not intimidating or gatekeeping
+- Not a wine encyclopedia or reference app
+- Not just for experts or snobs
+- Not a shopping/e-commerce app (though we help you find wines)
+
+---
+
+## Brand Personality
+
+### Four Pillars
+
+| Pillar | What It Means | How It Shows Up |
+|--------|---------------|-----------------|
+| **Welcoming** | You belong here, even if you're new to wine | Friendly copy, no jargon without explanation, encouraging empty states |
+| **Curious** | Always learning, discovering, exploring | Journey-based learning, "discover" features, celebrating exploration |
+| **Premium** | Quality experience, not cheap or gimmicky | Polished UI, thoughtful details, sophisticated (not flashy) design |
+| **Smart** | AI-powered, intelligent, knows you | Personalized recommendations, learning your taste, insightful summaries |
+
+### Voice & Tone
+- Conversational but knowledgeable
+- Encouraging, never condescending
+- Concise - respect the user's time
+- Uses "you/your" - it's personal
+- Avoids wine snobbery and pretension
+
+*Examples TBD*
+
+---
+
+## Visual Identity
+
+### Logo
+
+**Status**: Final Candidates Under Review
+
+**Winning Direction: Top-Down Wine Glass**
+
+After extensive exploration, the winning concept is a **wine glass viewed from directly above** - showing the circular rim and the wine surface inside. This approach:
+- Is immediately recognizable as wine-related
+- Feels fresh and unexpected (most wine logos use side-view silhouettes)
+- Works as an app icon at all sizes
+- Balances literal (it's clearly a wine glass) with stylized (geometric, premium)
+
+**Final Candidate (Option 10)**:
+- Top-down view of wine glass
+- Deep purple wine surface filling the glass
+- White/silver rim creating the outer circle
+- Subtle pink highlight at bottom adding dimension
+- Clean black background
+
+**Key Learnings from Logo Exploration**:
+
+| Approach | Result |
+|----------|--------|
+| Abstract geometric (swirls, circles, drops) | Looked childish, generic, or like "AI art" - didn't read as wine |
+| Pure circles (target/bullseye style) | Too abstract, lost wine identity entirely |
+| Side-view wine glass | Too literal, every wine app does this |
+| **Top-down wine glass with wine inside** | ✅ Winner - fresh perspective, clearly wine, premium feel |
+
+**What We Learned About AI Logo Prompts**:
+1. "Wine glass" triggers side-view in AI models - had to describe geometry explicitly
+2. Longer, more detailed prompts worked better than short ones
+3. `--stylize 0` in Midjourney reduced unwanted artistic flourishes
+4. Referencing "tech startup" and "Spotify/Slack" helped push toward logo (not art) aesthetics
+5. Literal-but-stylized beats purely abstract every time
+
+**Prompts That Worked**:
+```
+professional app icon logo for tech startup, wine glass viewed from above,
+simple circular rim with filled purple center, clean corporate design like
+Spotify or Slack app icons, flat solid colors, no artistic effects no shine
+no bubbles, deep purple (#7c3aed) on black background, modern minimal
+Silicon Valley aesthetic --ar 1:1 --v 6 --stylize 0
+```
+
+```
+imagine wine glass from above as minimal logo, top-down view showing circular
+rim and deep purple wine surface inside, completely flat vector illustration,
+no shine no reflections no 3D effects, solid black background only, monochrome
+purple (#7c3aed) and white color scheme, clean geometric shapes, modern app
+icon style --ar 1:1 --v 6
+```
+
+### Color Palette
+
+#### Primary
+| Name | Hex | Usage |
+|------|-----|-------|
+| Deep Purple | `#581c87` | Primary brand color, dark variant |
+| Vibrant Purple | `#7c3aed` | Primary brand color, bright variant |
+
+#### Accent Colors
+| Name | Hex | Usage |
+|------|-----|-------|
+| Rose | `rose-500` to `pink-600` | Solo tasting actions |
+| Indigo | `indigo-500` to `purple-600` | Learning/journey actions |
+| Blue | `blue-500` to `purple-600` | Group/social actions |
+| Amber | `amber-500` to `orange-600` | Host/create actions |
+
+#### Semantic Colors
+| Name | Hex | Usage |
+|------|-----|-------|
+| Success | `#10b981` | Positive feedback, completed states |
+| Warning | `#f59e0b` | Caution, attention needed |
+| Error | `#ef4444` | Errors, destructive actions |
+| Info | `#3b82f6` | Informational messages |
+
+#### Neutrals
+| Name | Value | Usage |
+|------|-------|-------|
+| Text Primary | `white 100%` | Headlines, important text |
+| Text Secondary | `white 80%` | Body text |
+| Text Tertiary | `white 60%` | Supporting text, labels |
+| Text Disabled | `white 40%` | Disabled states, placeholders |
+
+### Typography
+
+**Status**: Using system defaults, custom font TBD
+
+**Direction**:
+- Clean, modern sans-serif
+- Rounded terminals for approachability
+- Good legibility at small sizes (mobile-first)
+
+*Font selection TBD*
+
+### UI Style
+
+#### Current Implementation
+- **Theme**: Dark mode only (light mode planned for future)
+- **Background**: Gradient (`slate-900` → `purple-900` → `slate-900`)
+- **Cards**: Glassmorphism (`backdrop-blur-xl`, `from-white/10 to-white/5`, `border-white/20`)
+- **Corners**: Generously rounded (`rounded-2xl`, `rounded-3xl`)
+- **Depth**: Subtle shadows, layered transparency
+
+#### Design Principles
+1. **Mobile-first** - Most wine moments happen on phones
+2. **Thumb-friendly** - Important actions in easy reach
+3. **Breathing room** - Generous spacing, not cramped
+4. **Progressive disclosure** - Don't overwhelm, reveal as needed
+
+---
+
+## Photography & Imagery
+
+*TBD*
+
+**Direction to explore**:
+- Warm, inviting lighting
+- Real moments (not staged stock photos)
+- Diverse people enjoying wine
+- Close-ups that feel intimate, not clinical
+- Avoid clichés (sunset vineyards, swirling glasses)
+
+---
+
+## Iconography
+
+*TBD*
+
+**Current approach**: Lucide icons (outline style)
+
+---
+
+## Motion & Animation
+
+**Current Implementation**:
+- Framer Motion for transitions
+- Subtle, purposeful animations
+- Haptic feedback on mobile
+
+**Principles**:
+- Animation should feel natural, not flashy
+- Use motion to guide attention
+- Celebrate achievements (completions, milestones)
+- Keep it fast - respect user's time
+
+---
+
+## App Icon
+
+**Direction**: The top-down wine glass icon IS the app icon.
+
+**Concept**: Looking down into a glass of wine - circular rim with purple wine surface inside.
+
+**Requirements**:
+- Recognizable at small sizes (29px - 1024px) ✅ Circular form scales well
+- Works on dark and light iOS/Android backgrounds - need to test light bg version
+- Distinct from other wine apps ✅ Most use side-view glasses
+- Conveys brand personality at a glance ✅ Premium, curious perspective
+
+**Variations Needed**:
+- Standard (dark background) - for iOS/Android app icon
+- Light background version - for contexts where dark bg doesn't work
+- Simplified version - for very small sizes (favicon, 16px)
+- Monochrome - for contexts requiring single color
+
+---
+
+## Future Sections
+
+**Immediate (Brand Overhaul)**:
+- [ ] Logo usage guidelines and clear space
+- [ ] Final color palette (refined from exploration)
+- [ ] Typography selection and scale
+- [ ] Updated component styles
+
+**Later**:
+- [ ] Color accessibility guidelines
+- [ ] Illustration style guide
+- [ ] Social media templates
+- [ ] Email design guidelines
+- [ ] Marketing materials guidelines
+- [ ] Co-branding guidelines
+- [ ] Light mode color palette
+
+---
+
+## Brand Overhaul Plan
+
+With the rebrand from **KnowYourGrape → Cata**, we have an opportunity to refresh the entire visual identity while preserving what works.
+
+### Phase 1: Logo Finalization
+- [ ] Collect colleague feedback on 11 logo options
+- [ ] Select final logo (current frontrunner: Option 10)
+- [ ] Create vector version in Illustrator/Figma
+- [ ] Design logo lockup (icon + "cata" wordmark)
+- [ ] Create logo variations (dark bg, light bg, monochrome)
+- [ ] Define clear space and minimum size rules
+
+### Phase 2: Typography Selection
+- [ ] Research typefaces that match brand pillars (Welcoming, Curious, Premium, Smart)
+- [ ] Test candidates: rounded sans-serifs (approachable) vs geometric sans-serifs (tech)
+- [ ] Consider: Inter, Plus Jakarta Sans, DM Sans, Outfit, or custom
+- [ ] Define type scale for app (headings, body, captions)
+- [ ] Pair with wordmark font for logo lockup
+
+### Phase 3: Color Refinement
+- [ ] Keep purple as primary (it works, reads "wine" without being literal)
+- [ ] Refine exact shades - current `#7c3aed` may shift slightly
+- [ ] Consider how logo colors (deep purple, white rim, pink highlight) influence palette
+- [ ] Audit current accent colors (rose, indigo, blue, amber) - are they all needed?
+- [ ] Define light mode palette (for future implementation)
+
+### Phase 4: App UI Updates
+- [ ] Update splash screen with new logo
+- [ ] Replace "KnowYourGrape" branding throughout app
+- [ ] Refresh HomeV2 cards to align with new visual direction
+- [ ] Consider if glassmorphism still fits or needs refinement
+- [ ] Update any illustrations or graphics with new style
+
+### Phase 5: Marketing & External
+- [ ] App Store / Play Store assets (icon, screenshots, preview video)
+- [ ] Social media profile images and banners
+- [ ] Website updates (if applicable)
+- [ ] Email templates
+- [ ] Pitch deck refresh
+
+---
+
+## Design Language Evolution
+
+### What to Keep
+- **Dark mode as primary** - feels premium, wine-appropriate
+- **Purple palette** - distinctive, reads "wine" subtly
+- **Generous spacing** - breathing room is welcoming
+- **Rounded corners** - approachable, modern
+- **Subtle animations** - polish without showiness
+
+### What to Evolve
+- **Glassmorphism** - may be getting dated; consider simplifying
+- **Gradient backgrounds** - evaluate if they compete with new logo
+- **Card styles** - could be cleaner, less "glass" effect
+- **Icon style** - current Lucide outline may not match new logo weight
+
+### Questions to Explore
+1. Should the top-down glass motif extend beyond the logo? (e.g., UI elements, illustrations)
+2. How prominent should the pink accent (from logo) be in the app?
+3. Does the current purple gradient background complement or compete with the logo?
+4. What's the right balance of playful vs premium?
+
+---
+
+## Logo Lockup Options
+
+Once final icon is selected, create these lockup variations:
+
+### Horizontal Lockup
+```
+[Icon] cata
+```
+- Icon to left, wordmark to right
+- Use for headers, navigation, wide spaces
+
+### Stacked Lockup
+```
+  [Icon]
+   cata
+```
+- Icon above, wordmark below
+- Use for square spaces, app splash, social profiles
+
+### Icon Only
+- Use when space is limited or brand is established
+- App icon, favicon, small UI elements
+
+### Wordmark Only
+- Use when logo is already visible nearby
+- Text-heavy contexts, legal, footer
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-01-21 | Initial brand brief created |
+| 2026-01-21 | Added logo concepts and AI prompts |
+| 2026-01-21 | Revised to icon-first approach (standalone symbols like Spotify/Apple) |
+| 2026-01-21 | Logo exploration complete - "top-down wine glass" wins over abstract approaches |
+| 2026-01-21 | Added brand overhaul plan, documented AI prompting learnings |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Note: Dev server runs Express which serves the Vite frontend. Port can be overri
 
 ## Architecture Overview
 
-**Know Your Grape** is a wine tasting education platform with two main experiences:
+**Cata** is a wine tasting education platform with two main experiences:
 
 1. **Live Sessions**: Host-led group tastings with real-time participant responses
 2. **Solo Tastings**: Self-guided tastings via Learning Journeys or ad-hoc wines
@@ -87,7 +87,7 @@ All question types in `client/src/components/questions/`:
 ## Deployment
 
 - **Platform**: Railway
-- **Production URL**: https://knowyourgrape-production.up.railway.app
+- **Production URL**: https://cata-production.up.railway.app
 - **Deploy trigger**: Push to `main` branch auto-deploys
 - **Config**: `railway.json` in repo root
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,11 @@ Note: Dev server runs Express which serves the Vite frontend. Port can be overri
 
 ## Architecture Overview
 
-**Cata** is a wine tasting education platform with two main experiences:
+**Cata** is a wine tasting education platform with three main experiences:
 
-1. **Live Sessions**: Host-led group tastings with real-time participant responses
-2. **Solo Tastings**: Self-guided tastings via Learning Journeys or ad-hoc wines
+1. **Solo Tastings**: Self-guided tastings via Learning Journeys or ad-hoc wines (snap any bottle)
+2. **Group Sessions**: Host-led tastings with real-time participant responses, voting, shared insights
+3. **Sommelier Tools**: Dashboard for wine professionals to create and manage tasting packages
 
 ### Tech Stack
 - **Backend**: Express + TypeScript (tsx), PostgreSQL with Drizzle ORM
@@ -37,7 +38,11 @@ server/
 └── openai-client.ts   # Sentiment analysis, summaries
 
 client/src/
-├── pages/             # Route components (Gateway, TastingSession, UserDashboard, etc.)
+├── pages/             # Route components
+│   ├── Landing.tsx        # Public landing page (/)
+│   ├── HomeV2.tsx         # Authenticated home with tabs (/home)
+│   ├── SommelierDashboard.tsx  # Package management (/sommelier)
+│   └── PackageEditor.tsx  # Slide/question builder (/editor/:code)
 ├── components/
 │   ├── questions/     # Question type components (MultipleChoice, Scale, Text, etc.)
 │   └── ui/            # shadcn/ui components + custom (video-player, audio-player, etc.)
@@ -83,11 +88,21 @@ All question types in `client/src/components/questions/`:
 - Solo tasting routes: `/api/solo/tastings`, `/api/solo/wines`, `/api/solo/preferences`
 - Journey routes: `/api/journeys`, `/api/journeys/:id/chapters/:chapterId/complete`
 - Dashboard: `/api/dashboard/:email`
+- Package routes: `/api/packages`, `/api/package-wines`, `/api/slides`
+- Session routes: `/api/sessions`, `/api/sessions/:id/participants`, `/api/sessions/:id/analytics`
+
+### Frontend Routes
+- `/` - Landing page (unauthenticated)
+- `/home` - Unified home with tabs: Solo, Group, Dashboard (authenticated)
+- `/sommelier` - Sommelier dashboard for creating packages
+- `/editor/:code` - Package slide editor
+- `/join` - Join a group session
+- `/tasting/:sessionId/:participantId` - Active tasting session
 
 ## Deployment
 
 - **Platform**: Railway
-- **Production URL**: https://cata-production.up.railway.app
+- **Production URL**: https://cata-production.up.railway.app (or https://cata.wine when DNS configured)
 - **Deploy trigger**: Push to `main` branch auto-deploys
 - **Config**: `railway.json` in repo root
 

--- a/PRODUCT_ROADMAP.md
+++ b/PRODUCT_ROADMAP.md
@@ -1,12 +1,51 @@
 # KYG Product Roadmap
 
-**Last Updated**: January 2026
+**Last Updated**: January 21, 2026
 
 ---
 
 ## Vision
 
-Transform KnowYourGrape into "your personal sommelier in your pocket" - an app that knows your taste, suggests wines you'll love, and makes learning about wine feel like play.
+Transform Cata into "your personal sommelier in your pocket" - an app that knows your taste, suggests wines you'll love, and makes learning about wine feel like play.
+
+---
+
+## Navigation Architecture: Three Pillars + Discover
+
+The app uses a bottom tab navigation with **three current tabs** and one **planned future tab**:
+
+| Tab | Purpose | User Intent | Status |
+|-----|---------|-------------|--------|
+| **Solo** | Personal wine journal & learning journeys | "Record my experience" | ✅ Live |
+| **Group** | Live sessions - join or host | "Taste with others" | ✅ Live |
+| **Dashboard** | All your data, insights, taste profile | "Understand my palate" | ✅ Live |
+| **Discover** | Wine recommendations & where to buy | "Find wines I'll love" | 🔮 Future |
+
+### Why These Tabs?
+
+Each tab represents a **distinct user intent** that doesn't overlap:
+- **Solo** = Capture (recording experiences)
+- **Group** = Connect (real-time with others)
+- **Dashboard** = Reflect (viewing your data)
+- **Discover** = Explore (finding new wines)
+
+### What Stays Within Existing Tabs
+
+| Feature | Location | Rationale |
+|---------|----------|-----------|
+| Learning Journeys | Solo tab | Different navigation depth, not a peer-level experience |
+| Gamification (streaks, badges) | Dashboard | Rewards for activity, part of your data |
+| Wine Collection Manager | Dashboard | Tracking what you own is part of your data |
+| Social features | TBD | Low priority; may not need dedicated tab |
+
+### When to Add the Discover Tab
+
+Add the **Discover tab** when Priority 2 (Wine Discovery & Recommendations) is implemented:
+- Personalized recommendations engine is built
+- Purchase integration is ready (Where to Buy, Price Alerts)
+- Enough content to justify dedicated navigation
+
+**Design constraint**: Maximum 4-5 bottom tabs for mobile usability.
 
 ---
 

--- a/client/index.html
+++ b/client/index.html
@@ -4,8 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <meta name="theme-color" content="#581c87" />
-    <meta name="description" content="Your personal sommelier for delightful wine tasting experiences." />
+    <meta name="description" content="Cata - Your personal sommelier for wine tasting experiences." />
+    <title>Cata - Wine Tasting</title>
     <link rel="manifest" href="/manifest.json" />
+    <!-- SVG favicon with dark mode support -->
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <!-- PNG fallback -->
     <link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192x192.png" />
   </head>
   <body>

--- a/client/public/favicon.svg
+++ b/client/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <defs>
+    <radialGradient id="wineGradientFav" cx="50%" cy="50%" r="50%" fx="40%" fy="40%">
+      <stop offset="0%" stop-color="#9333ea"/>
+      <stop offset="100%" stop-color="#581c87"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Simplified for small size -->
+  <circle cx="16" cy="16" r="14" fill="none" stroke="#E8E6ED" stroke-width="2"/>
+  <circle cx="16" cy="16" r="12" fill="url(#wineGradientFav)"/>
+  <circle cx="11" cy="11" r="2" fill="rgba(255,255,255,0.2)"/>
+</svg>

--- a/client/public/favicon.svg
+++ b/client/public/favicon.svg
@@ -1,13 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
   <defs>
-    <radialGradient id="wineGradientFav" cx="50%" cy="50%" r="50%" fx="40%" fy="40%">
-      <stop offset="0%" stop-color="#9333ea"/>
-      <stop offset="100%" stop-color="#581c87"/>
+    <radialGradient id="wineGradientFav" cx="50%" cy="45%" r="45%">
+      <stop offset="0%" stop-color="#5a2d6e"/>
+      <stop offset="100%" stop-color="#2a1233"/>
     </radialGradient>
+    <linearGradient id="rimGradientFav" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2a2a30"/>
+      <stop offset="50%" stop-color="#1a1a1e"/>
+      <stop offset="100%" stop-color="#2a2a30"/>
+    </linearGradient>
   </defs>
 
   <!-- Simplified for small size -->
-  <circle cx="16" cy="16" r="14" fill="none" stroke="#E8E6ED" stroke-width="2"/>
-  <circle cx="16" cy="16" r="12" fill="url(#wineGradientFav)"/>
-  <circle cx="11" cy="11" r="2" fill="rgba(255,255,255,0.2)"/>
+  <!-- Dark rim -->
+  <circle cx="16" cy="16" r="15" fill="url(#rimGradientFav)"/>
+  <!-- Rim highlight -->
+  <path d="M 6 11 A 12 12 0 0 1 16 4" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- White inner rim -->
+  <circle cx="16" cy="16" r="11.5" fill="none" stroke="rgba(220,220,225,0.7)" stroke-width="1"/>
+  <!-- Inner dark -->
+  <circle cx="16" cy="16" r="10" fill="#151518"/>
+  <!-- Wine -->
+  <circle cx="16" cy="16" r="8.5" fill="url(#wineGradientFav)"/>
+  <!-- Pink hint at bottom -->
+  <path d="M 9 18 A 7 7 0 0 0 23 18 A 8 4 0 0 1 9 18" fill="rgba(180,80,160,0.5)"/>
 </svg>

--- a/client/public/logo-cata-horizontal.svg
+++ b/client/public/logo-cata-horizontal.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40" width="160" height="40">
+  <defs>
+    <!-- Wine gradient - deep purple -->
+    <radialGradient id="wineGradientH" cx="50%" cy="50%" r="50%" fx="40%" fy="40%">
+      <stop offset="0%" stop-color="#9333ea"/>
+      <stop offset="100%" stop-color="#581c87"/>
+    </radialGradient>
+    <!-- Rim highlight -->
+    <linearGradient id="rimGradientH" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="50%" stop-color="#e8e6ed"/>
+      <stop offset="100%" stop-color="#d4d0db"/>
+    </linearGradient>
+    <!-- Subtle pink reflection -->
+    <radialGradient id="reflectionGradientH" cx="70%" cy="70%" r="40%" fx="70%" fy="70%">
+      <stop offset="0%" stop-color="#ec4899" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#581c87" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Icon: Top-down wine glass (scaled down) -->
+  <g transform="translate(4, 4)">
+    <!-- Outer rim -->
+    <circle cx="16" cy="16" r="14" fill="none" stroke="url(#rimGradientH)" stroke-width="2"/>
+    <!-- Wine surface -->
+    <circle cx="16" cy="16" r="12" fill="url(#wineGradientH)"/>
+    <!-- Pink reflection -->
+    <circle cx="16" cy="16" r="12" fill="url(#reflectionGradientH)"/>
+    <!-- Highlight -->
+    <circle cx="11" cy="11" r="3" fill="rgba(255,255,255,0.15)"/>
+  </g>
+
+  <!-- Wordmark: "cata" -->
+  <text x="48" y="28" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="24" font-weight="600" fill="#E8E6ED" letter-spacing="-0.5">cata</text>
+</svg>

--- a/client/public/logo-cata-horizontal.svg
+++ b/client/public/logo-cata-horizontal.svg
@@ -1,35 +1,46 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40" width="160" height="40">
   <defs>
-    <!-- Wine gradient - deep purple -->
-    <radialGradient id="wineGradientH" cx="50%" cy="50%" r="50%" fx="40%" fy="40%">
-      <stop offset="0%" stop-color="#9333ea"/>
-      <stop offset="100%" stop-color="#581c87"/>
+    <!-- Wine gradient -->
+    <radialGradient id="wineGradientH" cx="50%" cy="45%" r="45%" fx="45%" fy="40%">
+      <stop offset="0%" stop-color="#5a2d6e"/>
+      <stop offset="60%" stop-color="#3d1a4a"/>
+      <stop offset="100%" stop-color="#2a1233"/>
     </radialGradient>
-    <!-- Rim highlight -->
+
+    <!-- Glass rim gradient -->
     <linearGradient id="rimGradientH" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#ffffff"/>
-      <stop offset="50%" stop-color="#e8e6ed"/>
-      <stop offset="100%" stop-color="#d4d0db"/>
+      <stop offset="0%" stop-color="#2a2a30"/>
+      <stop offset="30%" stop-color="#1a1a1e"/>
+      <stop offset="70%" stop-color="#1a1a1e"/>
+      <stop offset="100%" stop-color="#2a2a30"/>
     </linearGradient>
-    <!-- Subtle pink reflection -->
-    <radialGradient id="reflectionGradientH" cx="70%" cy="70%" r="40%" fx="70%" fy="70%">
-      <stop offset="0%" stop-color="#ec4899" stop-opacity="0.4"/>
-      <stop offset="100%" stop-color="#581c87" stop-opacity="0"/>
-    </radialGradient>
+
+    <!-- Pink reflection -->
+    <linearGradient id="pinkReflectionH" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="rgba(200,100,180,0)"/>
+      <stop offset="70%" stop-color="rgba(200,100,180,0.4)"/>
+      <stop offset="100%" stop-color="rgba(180,80,160,0.6)"/>
+    </linearGradient>
   </defs>
 
-  <!-- Icon: Top-down wine glass (scaled down) -->
-  <g transform="translate(4, 4)">
-    <!-- Outer rim -->
-    <circle cx="16" cy="16" r="14" fill="none" stroke="url(#rimGradientH)" stroke-width="2"/>
+  <!-- Icon (scaled down) -->
+  <g transform="translate(2, 2)">
+    <!-- Outer dark rim -->
+    <circle cx="18" cy="18" r="17" fill="url(#rimGradientH)"/>
+    <!-- Rim highlight -->
+    <path d="M 7 13 A 14 14 0 0 1 18 4" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="3" stroke-linecap="round"/>
+    <!-- White inner rim -->
+    <circle cx="18" cy="18" r="13" fill="none" stroke="rgba(220,220,225,0.8)" stroke-width="1"/>
+    <!-- Inner dark -->
+    <circle cx="18" cy="18" r="12" fill="#151518"/>
     <!-- Wine surface -->
-    <circle cx="16" cy="16" r="12" fill="url(#wineGradientH)"/>
-    <!-- Pink reflection -->
-    <circle cx="16" cy="16" r="12" fill="url(#reflectionGradientH)"/>
+    <circle cx="18" cy="18" r="10.5" fill="url(#wineGradientH)"/>
     <!-- Highlight -->
-    <circle cx="11" cy="11" r="3" fill="rgba(255,255,255,0.15)"/>
+    <ellipse cx="16" cy="15" rx="5" ry="3" fill="rgba(255,255,255,0.08)"/>
+    <!-- Pink reflection -->
+    <path d="M 10 20 A 9 9 0 0 0 26 20 A 10 6 0 0 1 10 20" fill="url(#pinkReflectionH)"/>
   </g>
 
-  <!-- Wordmark: "cata" -->
-  <text x="48" y="28" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="24" font-weight="600" fill="#E8E6ED" letter-spacing="-0.5">cata</text>
+  <!-- Wordmark -->
+  <text x="46" y="27" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="22" font-weight="600" fill="#E8E6ED" letter-spacing="-0.5">cata</text>
 </svg>

--- a/client/public/logo-cata.svg
+++ b/client/public/logo-cata.svg
@@ -1,37 +1,55 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
   <defs>
-    <!-- Wine gradient - deep purple -->
-    <radialGradient id="wineGradient" cx="50%" cy="50%" r="50%" fx="40%" fy="40%">
-      <stop offset="0%" stop-color="#9333ea"/>
-      <stop offset="100%" stop-color="#581c87"/>
+    <!-- Wine gradient - deep purple with variation -->
+    <radialGradient id="wineGradient" cx="50%" cy="45%" r="45%" fx="45%" fy="40%">
+      <stop offset="0%" stop-color="#5a2d6e"/>
+      <stop offset="60%" stop-color="#3d1a4a"/>
+      <stop offset="100%" stop-color="#2a1233"/>
     </radialGradient>
-    <!-- Rim highlight -->
+
+    <!-- Glass rim gradient - dark with subtle highlights -->
     <linearGradient id="rimGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#ffffff"/>
-      <stop offset="50%" stop-color="#e8e6ed"/>
-      <stop offset="100%" stop-color="#d4d0db"/>
+      <stop offset="0%" stop-color="#2a2a30"/>
+      <stop offset="30%" stop-color="#1a1a1e"/>
+      <stop offset="70%" stop-color="#1a1a1e"/>
+      <stop offset="100%" stop-color="#2a2a30"/>
     </linearGradient>
-    <!-- Subtle pink reflection -->
-    <radialGradient id="reflectionGradient" cx="70%" cy="70%" r="40%" fx="70%" fy="70%">
-      <stop offset="0%" stop-color="#ec4899" stop-opacity="0.4"/>
-      <stop offset="100%" stop-color="#581c87" stop-opacity="0"/>
-    </radialGradient>
+
+    <!-- Highlight on glass rim -->
+    <linearGradient id="rimHighlight" x1="0%" y1="0%" x2="50%" y2="50%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.3)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+    </linearGradient>
+
+    <!-- Pink reflection at bottom -->
+    <linearGradient id="pinkReflection" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="rgba(200,100,180,0)"/>
+      <stop offset="70%" stop-color="rgba(200,100,180,0.4)"/>
+      <stop offset="100%" stop-color="rgba(180,80,160,0.6)"/>
+    </linearGradient>
   </defs>
 
-  <!-- Background (transparent for now, black can be added) -->
+  <!-- Outer dark glass rim -->
+  <circle cx="50" cy="50" r="46" fill="url(#rimGradient)"/>
 
-  <!-- Outer rim - white/silver circle -->
-  <circle cx="50" cy="50" r="46" fill="none" stroke="url(#rimGradient)" stroke-width="4"/>
+  <!-- Rim highlight (top-left) -->
+  <path d="M 20 35 A 38 38 0 0 1 50 12" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="8" stroke-linecap="round"/>
 
-  <!-- Inner rim shadow -->
-  <circle cx="50" cy="50" r="42" fill="none" stroke="rgba(0,0,0,0.2)" stroke-width="1"/>
+  <!-- White/silver inner rim line -->
+  <circle cx="50" cy="50" r="36" fill="none" stroke="rgba(220,220,225,0.8)" stroke-width="1.5"/>
 
-  <!-- Wine surface - deep purple -->
-  <circle cx="50" cy="50" r="40" fill="url(#wineGradient)"/>
+  <!-- Inner dark area (depth of glass) -->
+  <circle cx="50" cy="50" r="34" fill="#151518"/>
 
-  <!-- Pink highlight/reflection -->
-  <circle cx="50" cy="50" r="40" fill="url(#reflectionGradient)"/>
+  <!-- Wine surface -->
+  <circle cx="50" cy="50" r="30" fill="url(#wineGradient)"/>
 
-  <!-- Small highlight dot for dimension -->
-  <circle cx="35" cy="35" r="8" fill="rgba(255,255,255,0.15)"/>
+  <!-- Wine surface highlight (top) -->
+  <ellipse cx="45" cy="42" rx="15" ry="8" fill="rgba(255,255,255,0.08)"/>
+
+  <!-- Pink reflection on wine (bottom) -->
+  <path d="M 25 55 A 25 25 0 0 0 75 55 A 30 20 0 0 1 25 55" fill="url(#pinkReflection)"/>
+
+  <!-- Subtle surface sheen -->
+  <ellipse cx="50" cy="48" rx="22" ry="12" fill="none" stroke="rgba(255,255,255,0.05)" stroke-width="1"/>
 </svg>

--- a/client/public/logo-cata.svg
+++ b/client/public/logo-cata.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <defs>
+    <!-- Wine gradient - deep purple -->
+    <radialGradient id="wineGradient" cx="50%" cy="50%" r="50%" fx="40%" fy="40%">
+      <stop offset="0%" stop-color="#9333ea"/>
+      <stop offset="100%" stop-color="#581c87"/>
+    </radialGradient>
+    <!-- Rim highlight -->
+    <linearGradient id="rimGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="50%" stop-color="#e8e6ed"/>
+      <stop offset="100%" stop-color="#d4d0db"/>
+    </linearGradient>
+    <!-- Subtle pink reflection -->
+    <radialGradient id="reflectionGradient" cx="70%" cy="70%" r="40%" fx="70%" fy="70%">
+      <stop offset="0%" stop-color="#ec4899" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#581c87" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Background (transparent for now, black can be added) -->
+
+  <!-- Outer rim - white/silver circle -->
+  <circle cx="50" cy="50" r="46" fill="none" stroke="url(#rimGradient)" stroke-width="4"/>
+
+  <!-- Inner rim shadow -->
+  <circle cx="50" cy="50" r="42" fill="none" stroke="rgba(0,0,0,0.2)" stroke-width="1"/>
+
+  <!-- Wine surface - deep purple -->
+  <circle cx="50" cy="50" r="40" fill="url(#wineGradient)"/>
+
+  <!-- Pink highlight/reflection -->
+  <circle cx="50" cy="50" r="40" fill="url(#reflectionGradient)"/>
+
+  <!-- Small highlight dot for dimension -->
+  <circle cx="35" cy="35" r="8" fill="rgba(255,255,255,0.15)"/>
+</svg>

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "KnowYourGrape - Wine Tasting",
-  "short_name": "KnowGrape",
+  "name": "Cata - Wine Tasting",
+  "short_name": "Cata",
   "description": "Your personal sommelier for delightful wine tasting experiences.",
   "start_url": "/",
   "display": "standalone",

--- a/client/public/service-worker.js
+++ b/client/public/service-worker.js
@@ -1,8 +1,8 @@
 // client/public/service-worker.js
 
 // IMPORTANT: Increment this version string every time you deploy a new build!
-const CACHE_VERSION = "v1.4.0"; // Chrome compatibility update
-const CACHE_PREFIX = "knowyourgrape-shell-";
+const CACHE_VERSION = "v2.0.0"; // Brand overhaul - renamed to Cata
+const CACHE_PREFIX = "cata-shell-";
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
 // Only cache essential files - no aggressive caching

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { GlossaryProvider } from "@/contexts/GlossaryContext";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { useDynamicViewportHeight } from "@/hooks/useDynamicViewportHeight";
 import Gateway from "@/pages/Gateway";
+import Landing from "@/pages/Landing";
 import SessionJoin from "@/pages/SessionJoin";
 import TastingSession from "@/pages/TastingSession";
 import TastingCompletion from "@/pages/TastingCompletion";
@@ -33,7 +34,8 @@ import NotFound from "@/pages/not-found";
 function Router() {
   return (
     <Switch>
-      <Route path="/" component={Gateway} />
+      <Route path="/" component={Landing} />
+      <Route path="/gateway" component={Gateway} /> {/* Keep old gateway accessible */}
 
       {/* New unified home experience - Three Pillars (Solo, Group, Dashboard) */}
       <Route path="/home" component={HomeV2} />

--- a/client/src/components/SplashScreen.tsx
+++ b/client/src/components/SplashScreen.tsx
@@ -1,0 +1,34 @@
+import { motion } from 'framer-motion';
+
+const logoAnimation = {
+  initial: { opacity: 0, scale: 0.8 },
+  animate: { opacity: 1, scale: 1 },
+  transition: { duration: 0.3, ease: [0.4, 0, 0.2, 1] },
+} as const;
+
+export function SplashScreen() {
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 bg-gradient-primary flex items-center justify-center"
+      initial={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+    >
+      <motion.div className="text-center" {...logoAnimation}>
+        <img
+          src="/logo-cata.svg"
+          alt="Cata"
+          className="w-24 h-24 mx-auto mb-4"
+        />
+        <motion.p
+          className="text-white/60 text-sm"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.2, duration: 0.3 }}
+        >
+          Your personal sommelier
+        </motion.p>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/client/src/components/gateway/SelectionView.tsx
+++ b/client/src/components/gateway/SelectionView.tsx
@@ -59,22 +59,17 @@ export function SelectionView({
         initial="hidden"
         animate="visible"
       >
-        <motion.div
-          className="inline-flex items-center justify-center w-20 h-20 mb-6 rounded-full bg-white/10 backdrop-blur-xl border border-white/20 shadow-2xl"
+        <motion.img
+          src="/logo-cata.svg"
+          alt="Cata"
+          className="w-20 h-20 mb-6 mx-auto"
           variants={itemVariants}
           animate={{
             rotate: [0, 3, -3, 0],
             scale: [1, 1.02, 1],
-            boxShadow: [
-              "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
-              "0 30px 60px -12px rgba(139, 92, 246, 0.4)",
-              "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
-            ],
           }}
           transition={{ duration: 6, repeat: Infinity }}
-        >
-          <Wine className="text-white" size={36} />
-        </motion.div>
+        />
         
         <motion.h1
           className="text-3xl font-bold text-white mb-3 tracking-tight"

--- a/client/src/components/gateway/SelectionView.tsx
+++ b/client/src/components/gateway/SelectionView.tsx
@@ -86,7 +86,7 @@ export function SelectionView({
             backgroundClip: "text",
           }}
         >
-          KnowYourGrape
+          Cata
         </motion.h1>
         
         <motion.p

--- a/client/src/components/layout/HomeLayout.tsx
+++ b/client/src/components/layout/HomeLayout.tsx
@@ -65,7 +65,7 @@ export function HomeLayout({ children }: HomeLayoutProps) {
   // Loading state
   if (authLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center">
         <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
       </div>
     );
@@ -74,19 +74,21 @@ export function HomeLayout({ children }: HomeLayoutProps) {
   // Login view
   if (!isAuthenticated) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center p-4">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           className="w-full max-w-md"
         >
-          <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-3xl p-8 border border-white/20 shadow-2xl">
+          <div className="bg-white/5 backdrop-blur-md rounded-3xl p-8 border border-white/10 shadow-2xl">
             <div className="text-center mb-8">
-              <div className="w-20 h-20 mx-auto mb-4 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
-                <Wine className="w-10 h-10 text-white" />
-              </div>
-              <h1 className="text-2xl font-bold text-white mb-2">Know Your Grape</h1>
-              <p className="text-white/60">Your personal wine tasting journal</p>
+              <img
+                src="/logo-cata.svg"
+                alt="Cata - Wine Tasting"
+                className="w-20 h-20 mx-auto mb-4"
+              />
+              <h1 className="text-2xl font-bold text-white mb-2">Cata</h1>
+              <p className="text-white/60">Your personal sommelier</p>
             </div>
 
             <form onSubmit={handleLogin} className="space-y-4">
@@ -96,7 +98,7 @@ export function HomeLayout({ children }: HomeLayoutProps) {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="Enter your email"
-                  className="bg-white/10 border-white/20 text-white placeholder:text-white/40 py-3"
+                  className="bg-white/10 border-white/10 text-white placeholder:text-white/40 py-3"
                   required
                 />
               </div>
@@ -130,7 +132,7 @@ export function HomeLayout({ children }: HomeLayoutProps) {
   // Authenticated layout with tab bar
   return (
     <HomeUserContext.Provider value={{ user: authData.user }}>
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+      <div className="min-h-screen bg-gradient-primary">
         {/* Main content area with bottom padding for tab bar */}
         <main className="pb-24">{children}</main>
 

--- a/client/src/components/wine/PhotoCapture.tsx
+++ b/client/src/components/wine/PhotoCapture.tsx
@@ -121,13 +121,13 @@ export default function PhotoCapture({ onCapture, onCancel, isProcessing = false
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-primary flex items-center justify-center p-4">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         className="w-full max-w-md"
       >
-        <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-3xl p-6 border border-white/20 shadow-2xl">
+        <div className="bg-white/5 backdrop-blur-md rounded-3xl p-6 border border-white/10 shadow-2xl">
           {/* Header */}
           <div className="flex items-center justify-between mb-6">
             <div>
@@ -197,7 +197,7 @@ export default function PhotoCapture({ onCapture, onCancel, isProcessing = false
                   <Button
                     variant="outline"
                     onClick={handleCancel}
-                    className="w-full border-white/20 text-white hover:bg-white/10"
+                    className="w-full border-white/10 text-white hover:bg-white/10"
                   >
                     Enter Manually Instead
                   </Button>
@@ -234,7 +234,7 @@ export default function PhotoCapture({ onCapture, onCancel, isProcessing = false
                   <Button
                     variant="outline"
                     onClick={() => { stopCamera(); setMode('select'); }}
-                    className="flex-1 border-white/20 text-white hover:bg-white/10"
+                    className="flex-1 border-white/10 text-white hover:bg-white/10"
                   >
                     Cancel
                   </Button>
@@ -279,7 +279,7 @@ export default function PhotoCapture({ onCapture, onCancel, isProcessing = false
                     variant="outline"
                     onClick={handleRetake}
                     disabled={isProcessing}
-                    className="flex-1 border-white/20 text-white hover:bg-white/10"
+                    className="flex-1 border-white/10 text-white hover:bg-white/10"
                   >
                     <RotateCcw className="w-4 h-4 mr-2" />
                     Retake

--- a/client/src/components/wine/WineEntryForm.tsx
+++ b/client/src/components/wine/WineEntryForm.tsx
@@ -160,13 +160,13 @@ export default function WineEntryForm({ onSubmit, onCancel, initialData }: WineE
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-primary flex items-center justify-center p-4">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         className="w-full max-w-md"
       >
-        <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-3xl p-6 border border-white/20 shadow-2xl">
+        <div className="bg-white/5 backdrop-blur-md rounded-3xl p-6 border border-white/10 shadow-2xl">
           {/* Header */}
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center gap-3">
@@ -243,7 +243,7 @@ export default function WineEntryForm({ onSubmit, onCancel, initialData }: WineE
                 onChange={(e) => setWineName(e.target.value)}
                 placeholder="e.g., Chateau Margaux 2015"
                 required
-                className="bg-white/10 border-white/20 text-white placeholder:text-white/40 focus:border-purple-500"
+                className="bg-white/10 border-white/10 text-white placeholder:text-white/40 focus:border-purple-500"
               />
             </div>
 
@@ -253,7 +253,7 @@ export default function WineEntryForm({ onSubmit, onCancel, initialData }: WineE
                 Wine Type
               </Label>
               <Select value={wineType} onValueChange={setWineType}>
-                <SelectTrigger className="bg-white/10 border-white/20 text-white">
+                <SelectTrigger className="bg-white/10 border-white/10 text-white">
                   <SelectValue placeholder="Select type" />
                 </SelectTrigger>
                 <SelectContent>
@@ -277,7 +277,7 @@ export default function WineEntryForm({ onSubmit, onCancel, initialData }: WineE
                 onChange={(e) => setWineRegion(e.target.value)}
                 placeholder="e.g., Bordeaux, France"
                 list="regions"
-                className="bg-white/10 border-white/20 text-white placeholder:text-white/40 focus:border-purple-500"
+                className="bg-white/10 border-white/10 text-white placeholder:text-white/40 focus:border-purple-500"
               />
               <datalist id="regions">
                 {COMMON_REGIONS.map((region) => (
@@ -292,7 +292,7 @@ export default function WineEntryForm({ onSubmit, onCancel, initialData }: WineE
                 Vintage
               </Label>
               <Select value={wineVintage} onValueChange={setWineVintage}>
-                <SelectTrigger className="bg-white/10 border-white/20 text-white">
+                <SelectTrigger className="bg-white/10 border-white/10 text-white">
                   <SelectValue placeholder="Select year" />
                 </SelectTrigger>
                 <SelectContent className="max-h-[200px]">
@@ -317,7 +317,7 @@ export default function WineEntryForm({ onSubmit, onCancel, initialData }: WineE
                 onChange={(e) => setGrapeVariety(e.target.value)}
                 placeholder="e.g., Cabernet Sauvignon"
                 list="grapes"
-                className="bg-white/10 border-white/20 text-white placeholder:text-white/40 focus:border-purple-500"
+                className="bg-white/10 border-white/10 text-white placeholder:text-white/40 focus:border-purple-500"
               />
               <datalist id="grapes">
                 {COMMON_GRAPES.map((grape) => (

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -21,10 +21,10 @@ export function useAuth() {
         if (response.ok) {
           const data = await response.json();
           setUser(data.user);
-          localStorage.setItem("kyg_user_email", data.user.email);
+          localStorage.setItem("cata_user_email", data.user.email);
         } else {
           // No server session - check localStorage and try to establish session
-          const storedEmail = localStorage.getItem("kyg_user_email");
+          const storedEmail = localStorage.getItem("cata_user_email");
           if (storedEmail) {
             // Try to establish server session with stored email
             const authResponse = await fetch("/api/auth", {
@@ -39,14 +39,14 @@ export function useAuth() {
               setUser(data.user);
             } else {
               // Auth failed - clear localStorage
-              localStorage.removeItem("kyg_user_email");
+              localStorage.removeItem("cata_user_email");
             }
           }
         }
       } catch (error) {
         console.error("Auth check failed:", error);
         // Fall back to localStorage only
-        const storedEmail = localStorage.getItem("kyg_user_email");
+        const storedEmail = localStorage.getItem("cata_user_email");
         if (storedEmail) {
           setUser({ email: storedEmail });
         }
@@ -69,7 +69,7 @@ export function useAuth() {
 
       if (response.ok) {
         const data = await response.json();
-        localStorage.setItem("kyg_user_email", email);
+        localStorage.setItem("cata_user_email", email);
         setUser(data.user);
         return { success: true };
       } else {
@@ -79,7 +79,7 @@ export function useAuth() {
     } catch (error) {
       console.error("Login failed:", error);
       // Fallback to localStorage only
-      localStorage.setItem("kyg_user_email", email);
+      localStorage.setItem("cata_user_email", email);
       setUser({ email });
       return { success: true };
     }
@@ -94,7 +94,7 @@ export function useAuth() {
     } catch (error) {
       console.error("Logout failed:", error);
     }
-    localStorage.removeItem("kyg_user_email");
+    localStorage.removeItem("cata_user_email");
     setUser(null);
   }, []);
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,27 +3,27 @@
 @tailwind utilities;
 
 :root {
-  /* Primary gradients */
-  --gradient-primary: linear-gradient(135deg, #581c87 0%, #1e1b4b 50%, #000000 100%);
-  --gradient-card: linear-gradient(135deg, rgba(88, 28, 135, 0.2) 0%, rgba(30, 27, 75, 0.2) 100%);
+  /* Primary gradients - simplified for Cata rebrand */
+  --gradient-primary: linear-gradient(180deg, #0f0a1a 0%, #1a0f24 100%);
+  --gradient-card: linear-gradient(135deg, rgba(88, 28, 135, 0.15) 0%, rgba(30, 27, 75, 0.1) 100%);
   --gradient-button: linear-gradient(135deg, #7c3aed 0%, #581c87 100%);
-  
-  /* Glassmorphism */
+
+  /* Glassmorphism - reduced blur for better performance */
   --glass-bg: rgba(88, 28, 135, 0.1);
-  --glass-border: rgba(147, 51, 234, 0.2);
-  --glass-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.37);
-  
+  --glass-border: rgba(147, 51, 234, 0.15);
+  --glass-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.25);
+
   /* Semantic colors */
   --color-success: #10b981;
   --color-warning: #f59e0b;
   --color-error: #ef4444;
   --color-info: #3b82f6;
-  
-  /* Text hierarchy */
-  --text-primary: rgba(255, 255, 255, 1);
-  --text-secondary: rgba(255, 255, 255, 0.8);
-  --text-tertiary: rgba(255, 255, 255, 0.6);
-  --text-disabled: rgba(255, 255, 255, 0.4);
+
+  /* Text hierarchy - off-white for better readability */
+  --text-primary: #E8E6ED;
+  --text-secondary: rgba(232, 230, 237, 0.8);
+  --text-tertiary: rgba(232, 230, 237, 0.6);
+  --text-disabled: rgba(232, 230, 237, 0.4);
 
   /* Dark theme colors in HSL */
   --background: 240 10% 3.9%;
@@ -144,9 +144,28 @@
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
-/* Glassmorphism enhancements */
+/* Glassmorphism enhancements - reduced blur for better mobile performance */
 .backdrop-blur-xl {
   backdrop-filter: blur(24px);
+}
+
+/* Reduced blur on mobile for performance */
+@media (max-width: 768px) {
+  .backdrop-blur-xl {
+    backdrop-filter: blur(12px);
+  }
+  .backdrop-blur-md {
+    backdrop-filter: blur(8px);
+  }
+}
+
+/* Accessibility: respect user preferences for reduced transparency */
+@media (prefers-reduced-transparency: reduce) {
+  .backdrop-blur-xl,
+  .backdrop-blur-md {
+    backdrop-filter: none;
+    background: rgba(15, 10, 26, 0.95);
+  }
 }
 
 /* Custom animations */

--- a/client/src/pages/HomeTastings.tsx
+++ b/client/src/pages/HomeTastings.tsx
@@ -89,10 +89,11 @@ export default function HomeTastings() {
       {/* Header */}
       <header className="sticky top-0 z-40 bg-black/30 backdrop-blur-xl border-b border-white/10">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Wine className="w-6 h-6 text-purple-400" />
-            <span className="text-white font-semibold">Know Your Grape</span>
-          </div>
+          <img
+            src="/logo-cata-horizontal.svg"
+            alt="Cata"
+            className="h-8 w-auto"
+          />
           <span className="text-white/60 text-sm hidden sm:block truncate max-w-[150px]">
             {user.email}
           </span>
@@ -168,7 +169,7 @@ export default function HomeTastings() {
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.15 }}
-            className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-5 border border-white/20"
+            className="bg-white/5 backdrop-blur-md rounded-2xl p-5 border border-white/10"
           >
             <div className="flex items-center gap-2 mb-3">
               <Sparkles className="w-5 h-5 text-purple-400" />
@@ -215,7 +216,7 @@ export default function HomeTastings() {
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: 0.05 * index }}
                   onClick={() => setLocation(`/solo/tasting/${tasting.id}`)}
-                  className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-xl p-4 border border-white/20 cursor-pointer hover:bg-white/15 transition-colors"
+                  className="bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 cursor-pointer hover:bg-white/15 transition-colors"
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex-1 min-w-0">
@@ -285,7 +286,7 @@ function StatCard({
   };
 
   return (
-    <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-xl p-3 border border-white/20">
+    <div className="bg-white/5 backdrop-blur-md rounded-xl p-3 border border-white/10">
       <div className={`w-8 h-8 rounded-lg flex items-center justify-center mb-2 ${colorClasses[color]}`}>
         <Icon className="w-4 h-4" />
       </div>
@@ -304,7 +305,7 @@ function EmptyTastingsCard({ onStartTasting }: { onStartTasting: () => void }) {
       <Button
         onClick={onStartTasting}
         variant="outline"
-        className="border-white/20 text-white hover:bg-white/10"
+        className="border-white/10 text-white hover:bg-white/10"
       >
         Start Your First Tasting
       </Button>

--- a/client/src/pages/HomeTastings.tsx
+++ b/client/src/pages/HomeTastings.tsx
@@ -66,7 +66,7 @@ export default function HomeTastings() {
   const handleLogout = async () => {
     try {
       await apiRequest("POST", "/api/auth/logout", null);
-      localStorage.removeItem("kyg_user_email");
+      localStorage.removeItem("cata_user_email");
       queryClient.clear();
       setLocation("/");
     } catch (error) {

--- a/client/src/pages/HomeV2.tsx
+++ b/client/src/pages/HomeV2.tsx
@@ -112,7 +112,7 @@ export default function HomeV2() {
   // Loading state
   if (authLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center">
         <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
       </div>
     );
@@ -121,21 +121,23 @@ export default function HomeV2() {
   // Login view
   if (!isAuthenticated) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center p-4">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           className="w-full max-w-md"
         >
-          <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-3xl p-8 border border-white/20 shadow-2xl">
+          <div className="bg-white/5 backdrop-blur-md rounded-3xl p-8 border border-white/10 shadow-2xl">
             <div className="text-center mb-8">
-              <div className="w-20 h-20 mx-auto mb-4 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
-                <Wine className="w-10 h-10 text-white" />
-              </div>
+              <img
+                src="/logo-cata.svg"
+                alt="Cata - Wine Tasting"
+                className="w-20 h-20 mx-auto mb-4"
+              />
               <h1 className="text-2xl font-bold text-white mb-2">
-                Know Your Grape
+                Cata
               </h1>
-              <p className="text-white/60">Your personal wine journey</p>
+              <p className="text-white/60">Your personal sommelier</p>
             </div>
 
             <form onSubmit={handleLogin} className="space-y-4">
@@ -145,7 +147,7 @@ export default function HomeV2() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="Enter your email"
-                  className="bg-white/10 border-white/20 text-white placeholder:text-white/40 py-3"
+                  className="bg-white/10 border-white/10 text-white placeholder:text-white/40 py-3"
                   required
                 />
               </div>
@@ -178,7 +180,7 @@ export default function HomeV2() {
 
   // Authenticated layout with three tabs
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <div className="min-h-screen bg-gradient-primary">
       <main className="pb-24">
         <AnimatePresence mode="wait">
           {activeTab === "solo" && (
@@ -327,10 +329,11 @@ function SoloTabContent({ user }: TabContentProps) {
       {/* Header */}
       <header className="sticky top-0 z-40 bg-black/30 backdrop-blur-xl border-b border-white/10">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Wine className="w-6 h-6 text-purple-400" />
-            <span className="text-white font-semibold">Know Your Grape</span>
-          </div>
+          <img
+            src="/logo-cata-horizontal.svg"
+            alt="Cata"
+            className="h-8 w-auto"
+          />
           <span className="text-white/60 text-sm hidden sm:block truncate max-w-[150px]">
             {user.email}
           </span>
@@ -391,7 +394,7 @@ function SoloTabContent({ user }: TabContentProps) {
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.15 }}
-            className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-5 border border-white/20"
+            className="bg-white/5 backdrop-blur-md rounded-2xl p-5 border border-white/10"
           >
             <div className="flex items-center gap-2 mb-3">
               <GraduationCap className="w-5 h-5 text-purple-400" />
@@ -433,7 +436,7 @@ function SoloTabContent({ user }: TabContentProps) {
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.25 }}
-              className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-5 border border-white/20"
+              className="bg-white/5 backdrop-blur-md rounded-2xl p-5 border border-white/10"
             >
               <div className="flex items-center gap-2 mb-3">
                 <Sparkles className="w-5 h-5 text-purple-400" />
@@ -485,7 +488,7 @@ function SoloTabContent({ user }: TabContentProps) {
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: 0.05 * index }}
                   onClick={() => setLocation(`/solo/tasting/${tasting.id}`)}
-                  className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-xl p-4 border border-white/20 cursor-pointer hover:bg-white/15 transition-colors"
+                  className="bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 cursor-pointer hover:bg-white/15 transition-colors"
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex-1 min-w-0">
@@ -532,7 +535,7 @@ function SoloTabContent({ user }: TabContentProps) {
               <Button
                 onClick={() => setLocation("/tasting/new")}
                 variant="outline"
-                className="border-white/20 text-white hover:bg-white/10"
+                className="border-white/10 text-white hover:bg-white/10"
               >
                 Start Your First Tasting
               </Button>
@@ -866,7 +869,7 @@ function GroupTabContent({ user }: TabContentProps) {
                             `/dashboard/${encodeURIComponent(user.email)}/tasting/${tasting.sessionId}`
                           )
                         }
-                        className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-xl p-4 border border-white/20 cursor-pointer hover:bg-white/15 transition-colors"
+                        className="bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 cursor-pointer hover:bg-white/15 transition-colors"
                       >
                         <div className="flex items-start justify-between">
                           <div className="flex-1 min-w-0">
@@ -952,7 +955,7 @@ function GroupTabContent({ user }: TabContentProps) {
               initial={{ scale: 0.9, opacity: 0, y: 50 }}
               animate={{ scale: 1, opacity: 1, y: 0 }}
               exit={{ scale: 0.9, opacity: 0, y: 50 }}
-              className="bg-white/10 backdrop-blur-xl rounded-3xl p-6 border border-white/20 max-w-sm w-full"
+              className="bg-white/10 backdrop-blur-xl rounded-3xl p-6 border border-white/10 max-w-sm w-full"
               onClick={(e) => e.stopPropagation()}
             >
               <div className="flex justify-between items-center mb-6">
@@ -1145,7 +1148,7 @@ function DashboardTabContent({ user }: TabContentProps) {
             transition={{ delay: 0.15 }}
             className="grid grid-cols-2 gap-4"
           >
-            <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-4 border border-white/20">
+            <div className="bg-white/5 backdrop-blur-md rounded-2xl p-4 border border-white/10">
               <div className="flex items-center gap-2 mb-2">
                 <MapPin className="w-4 h-4 text-purple-400" />
                 <span className="text-white/60 text-sm">Top Region</span>
@@ -1154,7 +1157,7 @@ function DashboardTabContent({ user }: TabContentProps) {
                 {dashboardData.topPreferences.topRegion?.name || "Not enough data"}
               </p>
             </div>
-            <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-4 border border-white/20">
+            <div className="bg-white/5 backdrop-blur-md rounded-2xl p-4 border border-white/10">
               <div className="flex items-center gap-2 mb-2">
                 <Wine className="w-4 h-4 text-pink-400" />
                 <span className="text-white/60 text-sm">Top Grape</span>
@@ -1205,7 +1208,7 @@ function DashboardTabContent({ user }: TabContentProps) {
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.25 }}
-          className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-5 border border-white/20"
+          className="bg-white/5 backdrop-blur-md rounded-2xl p-5 border border-white/10"
         >
           <div className="flex items-center gap-2 mb-4">
             <Sparkles className="w-5 h-5 text-purple-400" />
@@ -1255,7 +1258,7 @@ function DashboardTabContent({ user }: TabContentProps) {
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.3 }}
           onClick={() => setLocation(`/dashboard/${encodeURIComponent(user.email)}`)}
-          className="w-full bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-5 border border-white/20 flex items-center justify-between group hover:bg-white/15 transition-all"
+          className="w-full bg-white/5 backdrop-blur-md rounded-2xl p-5 border border-white/10 flex items-center justify-between group hover:bg-white/15 transition-all"
         >
           <div className="flex items-center gap-4">
             <div className="w-12 h-12 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
@@ -1299,7 +1302,7 @@ function StatCard({
   };
 
   return (
-    <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-xl p-3 border border-white/20">
+    <div className="bg-white/5 backdrop-blur-md rounded-xl p-3 border border-white/10">
       <div
         className={`w-8 h-8 rounded-lg flex items-center justify-center mb-2 ${colorClasses[color]}`}
       >

--- a/client/src/pages/HomeV2.tsx
+++ b/client/src/pages/HomeV2.tsx
@@ -154,7 +154,7 @@ export default function HomeV2() {
   const handleLogout = async () => {
     try {
       await apiRequest("POST", "/api/auth/logout", null);
-      localStorage.removeItem("kyg_user_email");
+      localStorage.removeItem("cata_user_email");
       queryClient.clear();
       setLocation("/");
     } catch (error) {

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -118,22 +118,22 @@ export default function Landing() {
           <FeatureCard
             icon={Users}
             title="Group Tastings"
-            description="Host dinner parties with friends"
+            description="All the software to host a wine dinner — guided questions, live voting, shared insights"
           />
           <FeatureCard
             icon={Camera}
             title="Snap & Learn"
-            description="Snap any bottle, get guided, build your profile"
+            description="Photo any bottle, we'll guide you through tasting it properly and save your notes"
           />
           <FeatureCard
             icon={BookOpen}
             title="Guided Journeys"
-            description="Pick up wines at your local shop"
+            description="Pick wines at your local shop, follow sommelier-designed tastings at home"
           />
           <FeatureCard
             icon={MapPin}
             title="Take Action"
-            description="Order smart at restaurants"
+            description="Know exactly what to order at restaurants or add to your collection"
           />
         </div>
       </motion.section>

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import { useLocation } from "wouter";
-import { Wine, Sparkles, Brain, ArrowRight, Users, UserPlus, GraduationCap } from "lucide-react";
+import { Wine, Sparkles, ArrowRight, GraduationCap, MessageCircle, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const containerVariants = {
@@ -88,8 +88,8 @@ export default function Landing() {
       >
         <div className="flex justify-center gap-4 max-w-md mx-auto">
           <MetricCard icon={Wine} value="500+" label="Wines" />
-          <MetricCard icon={Sparkles} value="10k+" label="Tastings" />
-          <MetricCard icon={Brain} value="AI" label="Powered" />
+          <MetricCard icon={User} value="Real" label="Sommeliers" />
+          <MetricCard icon={Sparkles} value="AI" label="Insights" />
         </div>
       </motion.section>
 
@@ -113,7 +113,7 @@ export default function Landing() {
           <StepCard
             number={2}
             title="Learn Your Palate"
-            description="AI builds your unique preference profile"
+            description="AI + real sommeliers build your preference profile"
           />
           <StepCard
             number={3}
@@ -139,18 +139,26 @@ export default function Landing() {
         </Button>
       </motion.section>
 
-      {/* Professional Section */}
+      {/* Sommelier Value Prop */}
       <motion.section
         className="py-10 px-4 border-t border-white/10"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 1 }}
       >
-        <h3 className="text-lg font-medium text-white/80 text-center mb-6">
-          For Wine Professionals
+        <h3 className="text-lg font-medium text-white text-center mb-2">
+          Powered by Real Sommeliers
         </h3>
+        <p className="text-white/60 text-sm text-center max-w-xs mx-auto mb-6">
+          Every tasting and journey is crafted by certified sommeliers. Get live guidance or have experts review your palate.
+        </p>
 
         <div className="max-w-sm mx-auto space-y-4">
+          {/* For Wine Professionals */}
+          <p className="text-white/40 text-xs text-center uppercase tracking-wide">
+            For Wine Professionals
+          </p>
+
           {/* Sommelier Dashboard */}
           <button
             onClick={() => setLocation("/sommelier")}
@@ -166,23 +174,20 @@ export default function Landing() {
             <ArrowRight className="w-5 h-5 text-white/40" />
           </button>
 
-          {/* Host & Join Row */}
-          <div className="flex gap-3">
-            <button
-              onClick={() => setLocation("/join")}
-              className="flex-1 bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 flex items-center gap-3 hover:bg-white/10 transition-colors"
-            >
-              <Users className="w-5 h-5 text-blue-400" />
-              <span className="text-white text-sm">Join Session</span>
-            </button>
-            <button
-              onClick={() => setLocation("/join")}
-              className="flex-1 bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 flex items-center gap-3 hover:bg-white/10 transition-colors"
-            >
-              <UserPlus className="w-5 h-5 text-green-400" />
-              <span className="text-white text-sm">Host Session</span>
-            </button>
-          </div>
+          {/* Contact Team */}
+          <button
+            onClick={() => window.location.href = "mailto:hello@cata.wine"}
+            className="w-full bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 flex items-center gap-4 hover:bg-white/10 transition-colors text-left"
+          >
+            <div className="bg-gradient-to-br from-purple-500 to-pink-600 p-2.5 rounded-lg">
+              <MessageCircle className="w-5 h-5 text-white" />
+            </div>
+            <div className="flex-1">
+              <p className="text-white font-medium">Contact Our Team</p>
+              <p className="text-white/50 text-sm">Partner with us or get enterprise access</p>
+            </div>
+            <ArrowRight className="w-5 h-5 text-white/40" />
+          </button>
         </div>
 
         <p className="text-center text-white/30 text-xs mt-8">

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -1,0 +1,234 @@
+import { motion } from "framer-motion";
+import { useLocation } from "wouter";
+import { Wine, Sparkles, Brain, ArrowRight, Users, UserPlus, GraduationCap } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.1 }
+  }
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 }
+};
+
+export default function Landing() {
+  const [, setLocation] = useLocation();
+
+  return (
+    <div className="min-h-screen bg-gradient-primary">
+      {/* Hero Section */}
+      <motion.section
+        className="pt-16 pb-8 px-4 text-center"
+        variants={containerVariants}
+        initial="hidden"
+        animate="visible"
+      >
+        <motion.img
+          src="/logo-cata.svg"
+          alt="Cata"
+          className="w-24 h-24 mx-auto mb-6"
+          variants={itemVariants}
+        />
+
+        <motion.h1
+          className="text-4xl font-bold text-white mb-3"
+          variants={itemVariants}
+          style={{
+            background: "linear-gradient(135deg, #ffffff 0%, #e0e7ff 100%)",
+            WebkitBackgroundClip: "text",
+            WebkitTextFillColor: "transparent",
+            backgroundClip: "text",
+          }}
+        >
+          Your Personal Sommelier
+        </motion.h1>
+
+        <motion.p
+          className="text-lg text-white/80 max-w-sm mx-auto mb-8 leading-relaxed"
+          variants={itemVariants}
+        >
+          Discover wines you'll love through guided tastings that learn your unique palate.
+        </motion.p>
+
+        <motion.div variants={itemVariants}>
+          <Button
+            onClick={() => setLocation("/home")}
+            className="w-full max-w-xs bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white py-6 text-lg rounded-2xl shadow-lg"
+          >
+            Start Tasting
+            <ArrowRight className="ml-2 w-5 h-5" />
+          </Button>
+        </motion.div>
+
+        <motion.p
+          className="mt-4 text-white/50 text-sm"
+          variants={itemVariants}
+        >
+          Already have an account?{" "}
+          <button
+            onClick={() => setLocation("/login")}
+            className="text-purple-300 hover:text-purple-200 underline"
+          >
+            Sign In
+          </button>
+        </motion.p>
+      </motion.section>
+
+      {/* Trust Metrics */}
+      <motion.section
+        className="py-8 px-4"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.4 }}
+      >
+        <div className="flex justify-center gap-4 max-w-md mx-auto">
+          <MetricCard icon={Wine} value="500+" label="Wines" />
+          <MetricCard icon={Sparkles} value="10k+" label="Tastings" />
+          <MetricCard icon={Brain} value="AI" label="Powered" />
+        </div>
+      </motion.section>
+
+      {/* How It Works */}
+      <motion.section
+        className="py-10 px-4"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.6 }}
+      >
+        <h2 className="text-xl font-semibold text-white text-center mb-8">
+          How It Works
+        </h2>
+
+        <div className="space-y-6 max-w-sm mx-auto">
+          <StepCard
+            number={1}
+            title="Taste & Rate"
+            description="Rate wines on aroma, taste, finish and more"
+          />
+          <StepCard
+            number={2}
+            title="Learn Your Palate"
+            description="AI builds your unique preference profile"
+          />
+          <StepCard
+            number={3}
+            title="Discover New Favorites"
+            description="Get personalized wine recommendations"
+          />
+        </div>
+      </motion.section>
+
+      {/* Bottom CTA */}
+      <motion.section
+        className="py-8 px-4 text-center"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.8 }}
+      >
+        <Button
+          onClick={() => setLocation("/home")}
+          variant="outline"
+          className="border-white/20 text-white hover:bg-white/10 py-5 px-8 rounded-xl"
+        >
+          Start Your Wine Journey
+        </Button>
+      </motion.section>
+
+      {/* Professional Section */}
+      <motion.section
+        className="py-10 px-4 border-t border-white/10"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1 }}
+      >
+        <h3 className="text-lg font-medium text-white/80 text-center mb-6">
+          For Wine Professionals
+        </h3>
+
+        <div className="max-w-sm mx-auto space-y-4">
+          {/* Sommelier Dashboard */}
+          <button
+            onClick={() => setLocation("/sommelier")}
+            className="w-full bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 flex items-center gap-4 hover:bg-white/10 transition-colors text-left"
+          >
+            <div className="bg-gradient-to-br from-amber-500 to-orange-600 p-2.5 rounded-lg">
+              <GraduationCap className="w-5 h-5 text-white" />
+            </div>
+            <div className="flex-1">
+              <p className="text-white font-medium">Sommelier Dashboard</p>
+              <p className="text-white/50 text-sm">Create and manage wine tastings</p>
+            </div>
+            <ArrowRight className="w-5 h-5 text-white/40" />
+          </button>
+
+          {/* Host & Join Row */}
+          <div className="flex gap-3">
+            <button
+              onClick={() => setLocation("/join")}
+              className="flex-1 bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 flex items-center gap-3 hover:bg-white/10 transition-colors"
+            >
+              <Users className="w-5 h-5 text-blue-400" />
+              <span className="text-white text-sm">Join Session</span>
+            </button>
+            <button
+              onClick={() => setLocation("/join")}
+              className="flex-1 bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 flex items-center gap-3 hover:bg-white/10 transition-colors"
+            >
+              <UserPlus className="w-5 h-5 text-green-400" />
+              <span className="text-white text-sm">Host Session</span>
+            </button>
+          </div>
+        </div>
+
+        <p className="text-center text-white/30 text-xs mt-8">
+          Cata - Premium Wine Tasting Experience
+        </p>
+      </motion.section>
+    </div>
+  );
+}
+
+function MetricCard({
+  icon: Icon,
+  value,
+  label,
+}: {
+  icon: typeof Wine;
+  value: string;
+  label: string;
+}) {
+  return (
+    <div className="bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 text-center flex-1">
+      <Icon className="w-5 h-5 text-purple-400 mx-auto mb-2" />
+      <div className="text-xl font-bold text-white">{value}</div>
+      <div className="text-xs text-white/50">{label}</div>
+    </div>
+  );
+}
+
+function StepCard({
+  number,
+  title,
+  description,
+}: {
+  number: number;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-start gap-4">
+      <div className="w-8 h-8 bg-gradient-to-br from-purple-500 to-pink-500 rounded-full flex items-center justify-center flex-shrink-0">
+        <span className="text-white font-bold text-sm">{number}</span>
+      </div>
+      <div>
+        <h3 className="text-white font-medium mb-1">{title}</h3>
+        <p className="text-white/60 text-sm">{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import { useLocation } from "wouter";
-import { Wine, Sparkles, ArrowRight, GraduationCap, MessageCircle, User } from "lucide-react";
+import { Wine, Sparkles, ArrowRight, GraduationCap, MessageCircle, User, Camera, Users, MapPin, BookOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const containerVariants = {
@@ -28,12 +28,19 @@ export default function Landing() {
         initial="hidden"
         animate="visible"
       >
-        <motion.img
-          src="/logo-cata.svg"
-          alt="Cata"
-          className="w-24 h-24 mx-auto mb-6"
+        <motion.div
+          className="relative w-28 h-28 mx-auto mb-6"
           variants={itemVariants}
-        />
+        >
+          {/* Glow effect behind logo */}
+          <div className="absolute inset-0 bg-purple-500/30 rounded-full blur-xl" />
+          <div className="absolute inset-2 bg-purple-400/20 rounded-full blur-md" />
+          <img
+            src="/logo-cata.svg"
+            alt="Cata"
+            className="relative w-full h-full drop-shadow-[0_0_15px_rgba(168,85,247,0.5)]"
+          />
+        </motion.div>
 
         <motion.h1
           className="text-4xl font-bold text-white mb-3"
@@ -93,12 +100,50 @@ export default function Landing() {
         </div>
       </motion.section>
 
-      {/* How It Works */}
+      {/* Features */}
       <motion.section
         className="py-10 px-4"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.6 }}
+      >
+        <h2 className="text-xl font-semibold text-white text-center mb-2">
+          Everything You Need
+        </h2>
+        <p className="text-white/60 text-sm text-center max-w-xs mx-auto mb-8">
+          From casual tastings to building your collection
+        </p>
+
+        <div className="grid grid-cols-2 gap-3 max-w-md mx-auto">
+          <FeatureCard
+            icon={Users}
+            title="Group Tastings"
+            description="Host dinner parties with friends"
+          />
+          <FeatureCard
+            icon={Camera}
+            title="Snap & Learn"
+            description="Photo any wine for instant info"
+          />
+          <FeatureCard
+            icon={BookOpen}
+            title="Guided Journeys"
+            description="Pick up wines at your local shop"
+          />
+          <FeatureCard
+            icon={MapPin}
+            title="Take Action"
+            description="Order smart at restaurants"
+          />
+        </div>
+      </motion.section>
+
+      {/* How It Works */}
+      <motion.section
+        className="py-10 px-4"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.8 }}
       >
         <h2 className="text-xl font-semibold text-white text-center mb-8">
           How It Works
@@ -112,13 +157,13 @@ export default function Landing() {
           />
           <StepCard
             number={2}
-            title="Learn Your Palate"
-            description="AI + real sommeliers build your preference profile"
+            title="Build Your Profile"
+            description="AI + real sommeliers learn your unique palate"
           />
           <StepCard
             number={3}
-            title="Discover New Favorites"
-            description="Get personalized wine recommendations"
+            title="Take Action"
+            description="Know what to order, collect, and explore"
           />
         </div>
       </motion.section>
@@ -128,7 +173,7 @@ export default function Landing() {
         className="py-8 px-4 text-center"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        transition={{ delay: 0.8 }}
+        transition={{ delay: 1 }}
       >
         <Button
           onClick={() => setLocation("/home")}
@@ -144,7 +189,7 @@ export default function Landing() {
         className="py-10 px-4 border-t border-white/10"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        transition={{ delay: 1 }}
+        transition={{ delay: 1.2 }}
       >
         <h3 className="text-lg font-medium text-white text-center mb-2">
           Powered by Real Sommeliers
@@ -234,6 +279,24 @@ function StepCard({
         <h3 className="text-white font-medium mb-1">{title}</h3>
         <p className="text-white/60 text-sm">{description}</p>
       </div>
+    </div>
+  );
+}
+
+function FeatureCard({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: typeof Wine;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10">
+      <Icon className="w-6 h-6 text-purple-400 mb-2" />
+      <h3 className="text-white font-medium text-sm mb-1">{title}</h3>
+      <p className="text-white/50 text-xs">{description}</p>
     </div>
   );
 }

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -123,7 +123,7 @@ export default function Landing() {
           <FeatureCard
             icon={Camera}
             title="Snap & Learn"
-            description="Photo any bottle, taste guided, add to your profile"
+            description="Snap any bottle, get guided, build your profile"
           />
           <FeatureCard
             icon={BookOpen}

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -123,7 +123,7 @@ export default function Landing() {
           <FeatureCard
             icon={Camera}
             title="Snap & Learn"
-            description="Photo any wine for instant info"
+            description="Photo any bottle, taste guided, add to your profile"
           />
           <FeatureCard
             icon={BookOpen}

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { LoadingOverlay } from "@/components/ui/loading-overlay";
-import { ArrowLeft, Mail, Wine, Loader2 } from "lucide-react";
+import { ArrowLeft, Mail, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 
@@ -110,9 +110,11 @@ export default function Login() {
         {/* Login Card */}
         <Card className="bg-white/10 backdrop-blur-xl border-white/20">
           <CardHeader className="text-center">
-            <div className="mx-auto mb-4 p-3 bg-purple-500/20 rounded-full w-fit">
-              <Wine className="w-8 h-8 text-purple-300" />
-            </div>
+            <img
+              src="/logo-cata.svg"
+              alt="Cata"
+              className="w-14 h-14 mx-auto mb-4"
+            />
             <CardTitle className="text-2xl font-bold text-white">Welcome Back</CardTitle>
             <CardDescription className="text-purple-200">
               Enter your email to access your wine tasting dashboard

--- a/client/src/pages/SoloDashboard.tsx
+++ b/client/src/pages/SoloDashboard.tsx
@@ -144,7 +144,7 @@ export default function SoloDashboard() {
   // Loading state
   if (authLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center">
         <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
       </div>
     );
@@ -153,19 +153,21 @@ export default function SoloDashboard() {
   // Login view
   if (view === 'login') {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center p-4">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           className="w-full max-w-md"
         >
-          <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-3xl p-8 border border-white/20 shadow-2xl">
+          <div className="bg-white/5 backdrop-blur-md rounded-3xl p-8 border border-white/10 shadow-2xl">
             <div className="text-center mb-8">
-              <div className="w-20 h-20 mx-auto mb-4 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
-                <Wine className="w-10 h-10 text-white" />
-              </div>
-              <h1 className="text-2xl font-bold text-white mb-2">Know Your Grape</h1>
-              <p className="text-white/60">Your personal wine tasting journal</p>
+              <img
+                src="/logo-cata.svg"
+                alt="Cata - Wine Tasting"
+                className="w-20 h-20 mx-auto mb-4"
+              />
+              <h1 className="text-2xl font-bold text-white mb-2">Cata</h1>
+              <p className="text-white/60">Your personal sommelier</p>
             </div>
 
             <form onSubmit={handleLogin} className="space-y-4">
@@ -175,7 +177,7 @@ export default function SoloDashboard() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="Enter your email"
-                  className="bg-white/10 border-white/20 text-white placeholder:text-white/40 py-3"
+                  className="bg-white/10 border-white/10 text-white placeholder:text-white/40 py-3"
                   required
                 />
               </div>
@@ -232,14 +234,15 @@ export default function SoloDashboard() {
 
   // Dashboard view
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <div className="min-h-screen bg-gradient-primary">
       {/* Header */}
       <header className="sticky top-0 z-50 bg-black/30 backdrop-blur-xl border-b border-white/10">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Wine className="w-6 h-6 text-purple-400" />
-            <span className="text-white font-semibold">Know Your Grape</span>
-          </div>
+          <img
+            src="/logo-cata-horizontal.svg"
+            alt="Cata"
+            className="h-8 w-auto"
+          />
           <div className="flex items-center gap-3">
             <span className="text-white/60 text-sm hidden sm:block">
               {authData?.user?.email}
@@ -285,7 +288,7 @@ export default function SoloDashboard() {
 
         {/* Preferences Summary */}
         {preferencesData && preferencesData.tastingCount > 0 && (
-          <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-6 mb-8 border border-white/20">
+          <div className="bg-white/5 backdrop-blur-md rounded-2xl p-6 mb-8 border border-white/10">
             <h2 className="text-lg font-semibold text-white mb-3">Your Taste Profile</h2>
             <p className="text-white/80">{preferencesData.summary}</p>
           </div>
@@ -307,7 +310,7 @@ export default function SoloDashboard() {
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   onClick={() => setLocation(`/solo/tasting/${tasting.id}`)}
-                  className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-xl p-4 border border-white/20 cursor-pointer hover:bg-white/15 transition-colors"
+                  className="bg-white/5 backdrop-blur-md rounded-xl p-4 border border-white/10 cursor-pointer hover:bg-white/15 transition-colors"
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
@@ -354,7 +357,7 @@ export default function SoloDashboard() {
               <Button
                 onClick={() => setView('wine-entry')}
                 variant="outline"
-                className="border-white/20 text-white hover:bg-white/10"
+                className="border-white/10 text-white hover:bg-white/10"
               >
                 Start Your First Tasting
               </Button>

--- a/client/src/pages/SoloLogin.tsx
+++ b/client/src/pages/SoloLogin.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { apiRequest } from "@/lib/queryClient";
-import { Wine, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import type { User as UserType } from "@shared/schema";
 
 export default function SoloLogin() {

--- a/client/src/pages/SoloLogin.tsx
+++ b/client/src/pages/SoloLogin.tsx
@@ -60,26 +60,28 @@ export default function SoloLogin() {
 
   if (authLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center">
         <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-primary flex items-center justify-center p-4">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         className="w-full max-w-md"
       >
-        <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-3xl p-8 border border-white/20 shadow-2xl">
+        <div className="bg-white/5 backdrop-blur-md rounded-3xl p-8 border border-white/10 shadow-2xl">
           <div className="text-center mb-8">
-            <div className="w-20 h-20 mx-auto mb-4 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
-              <Wine className="w-10 h-10 text-white" />
-            </div>
-            <h1 className="text-2xl font-bold text-white mb-2">Know Your Grape</h1>
-            <p className="text-white/60">Your personal wine tasting journal</p>
+            <img
+              src="/logo-cata.svg"
+              alt="Cata - Wine Tasting"
+              className="w-20 h-20 mx-auto mb-4"
+            />
+            <h1 className="text-2xl font-bold text-white mb-2">Cata</h1>
+            <p className="text-white/60">Your personal sommelier</p>
           </div>
 
           <form onSubmit={handleLogin} className="space-y-4">
@@ -89,7 +91,7 @@ export default function SoloLogin() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="Enter your email"
-                className="bg-white/10 border-white/20 text-white placeholder:text-white/40 py-3"
+                className="bg-white/10 border-white/10 text-white placeholder:text-white/40 py-3"
                 required
               />
             </div>

--- a/client/src/pages/SoloProfile.tsx
+++ b/client/src/pages/SoloProfile.tsx
@@ -58,7 +58,7 @@ export default function SoloProfile() {
 
   if (authLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center">
         <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
       </div>
     );
@@ -72,7 +72,7 @@ export default function SoloProfile() {
   const user = authData.user;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <div className="min-h-screen bg-gradient-primary">
       {/* Header */}
       <header className="sticky top-0 z-50 bg-black/30 backdrop-blur-xl border-b border-white/10">
         <div className="container mx-auto px-4 py-4">
@@ -94,7 +94,7 @@ export default function SoloProfile() {
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-6 border border-white/20"
+          className="bg-white/5 backdrop-blur-md rounded-2xl p-6 border border-white/10"
         >
           <div className="flex items-center gap-4">
             <div className="w-16 h-16 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
@@ -115,7 +115,7 @@ export default function SoloProfile() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.1 }}
-          className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-6 border border-white/20"
+          className="bg-white/5 backdrop-blur-md rounded-2xl p-6 border border-white/10"
         >
           <h3 className="text-lg font-semibold text-white mb-4">Your Stats</h3>
           <div className="flex items-center gap-6">
@@ -139,7 +139,7 @@ export default function SoloProfile() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.2 }}
-            className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-6 border border-white/20"
+            className="bg-white/5 backdrop-blur-md rounded-2xl p-6 border border-white/10"
           >
             <h3 className="text-lg font-semibold text-white mb-4">Your Taste Profile</h3>
             <p className="text-white/80 mb-4">{preferencesData.summary}</p>

--- a/client/src/pages/SoloTastingDetail.tsx
+++ b/client/src/pages/SoloTastingDetail.tsx
@@ -225,7 +225,7 @@ function ResponseSection({
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-5 border border-white/20"
+      className="bg-white/5 backdrop-blur-md rounded-2xl p-5 border border-white/10"
     >
       <div className="flex items-center gap-3 mb-4">
         <div className={`w-10 h-10 rounded-full bg-gradient-to-r ${info.color} flex items-center justify-center`}>
@@ -262,7 +262,7 @@ export default function SoloTastingDetail() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center">
         <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
       </div>
     );
@@ -270,8 +270,8 @@ export default function SoloTastingDetail() {
 
   if (error || !data?.tasting) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center p-4">
-        <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-6 border border-white/20 text-center max-w-md">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center p-4">
+        <div className="bg-white/5 backdrop-blur-md rounded-2xl p-6 border border-white/10 text-center max-w-md">
           <Wine className="w-12 h-12 text-white/30 mx-auto mb-4" />
           <h2 className="text-xl font-bold text-white mb-2">Tasting Not Found</h2>
           <p className="text-white/60 mb-4">
@@ -292,7 +292,7 @@ export default function SoloTastingDetail() {
   const responses = tasting.responses as Record<string, Record<string, any>>;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <div className="min-h-screen bg-gradient-primary">
       {/* Header */}
       <header className="sticky top-0 z-50 bg-black/30 backdrop-blur-xl border-b border-white/10">
         <div className="container mx-auto px-4 py-4">
@@ -327,7 +327,7 @@ export default function SoloTastingDetail() {
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-5 border border-white/20"
+          className="bg-white/5 backdrop-blur-md rounded-2xl p-5 border border-white/10"
         >
           <div className="flex items-start gap-4">
             <div className="w-16 h-16 bg-gradient-to-r from-purple-500 to-pink-500 rounded-xl flex items-center justify-center flex-shrink-0">

--- a/client/src/pages/SoloTastingSession.tsx
+++ b/client/src/pages/SoloTastingSession.tsx
@@ -491,11 +491,11 @@ export default function SoloTastingSession({ wine, onComplete, onCancel, chapter
   // Completion screen
   if (isComplete) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center p-4">
         <motion.div
           initial={{ opacity: 0, scale: 0.9 }}
           animate={{ opacity: 1, scale: 1 }}
-          className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-3xl p-8 border border-white/20 shadow-2xl text-center max-w-md"
+          className="bg-white/5 backdrop-blur-md rounded-3xl p-8 border border-white/10 shadow-2xl text-center max-w-md"
         >
           <div className="w-20 h-20 mx-auto mb-6 bg-gradient-to-r from-emerald-500 to-teal-500 rounded-full flex items-center justify-center">
             <CheckCircle className="w-10 h-10 text-white" />
@@ -516,7 +516,7 @@ export default function SoloTastingSession({ wine, onComplete, onCancel, chapter
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <div className="min-h-screen bg-gradient-primary">
       {/* Header */}
       <header className="sticky top-0 z-50 bg-black/30 backdrop-blur-xl border-b border-white/10">
         <div className="container mx-auto px-4 py-3">
@@ -576,7 +576,7 @@ export default function SoloTastingSession({ wine, onComplete, onCancel, chapter
             variant="outline"
             onClick={handlePrevious}
             disabled={currentQuestionIndex === 0}
-            className="flex-1 border-white/20 text-white hover:bg-white/10 disabled:opacity-30"
+            className="flex-1 border-white/10 text-white hover:bg-white/10 disabled:opacity-30"
           >
             <ArrowLeft className="w-4 h-4 mr-2" />
             Previous

--- a/client/src/pages/UserDashboard.tsx
+++ b/client/src/pages/UserDashboard.tsx
@@ -584,8 +584,8 @@ export default function UserDashboard() {
             {/*  <span className="hidden sm:inline">Back</span>*/}
             {/*</Button>*/}
             <div>
-              <h1 className="text-3xl font-bold text-white">KnowYourGrape</h1>
-              <p className="text-purple-200">Premium Wine Experience</p>
+              <h1 className="text-3xl font-bold text-white">Cata</h1>
+              <p className="text-purple-200">Your personal sommelier</p>
             </div>
           </div>
           <div className="flex items-center space-x-4">

--- a/plans/brand-overhaul-cata.md
+++ b/plans/brand-overhaul-cata.md
@@ -1,0 +1,627 @@
+# Brand Overhaul: KnowYourGrape → Cata
+
+## Enhancement Summary
+
+**Deepened on:** 2026-01-21
+**Research agents used:** 10 (Dark mode researcher, Glassmorphism researcher, SVG/React researcher, Splash screen researcher, TypeScript reviewer, Code simplicity reviewer, Architecture strategist, Performance oracle, Frontend-design skill, Web search)
+
+### Key Improvements
+1. **Complete file audit** - Found 10+ additional files with brand references not in original plan
+2. **IndexedDB migration required** - Database name change needs data migration strategy
+3. **Performance validation** - Backdrop-blur reduction confirmed as significant mobile performance win
+4. **Text contrast guidance** - Use off-white (#E8E6ED) instead of pure white for readability
+5. **Accessibility requirements** - Added proper ARIA labels for logo images
+
+### New Considerations Discovered
+- Inline Tailwind gradients bypass CSS variable changes - need to replace them
+- PWA manifest and service worker need cache-busting strategy
+- Consider CSS animation for splash screen instead of Framer Motion (25KB savings)
+- Future light mode support: adopt `.dark` class pattern now
+
+### Design Philosophy Note
+The frontend-design skill flagged that near-black + purple is becoming generic "AI startup" aesthetic. The logo (top-down wine glass) is distinctive. Consider whether to push further on color identity in future iterations.
+
+---
+
+## Overview
+
+Rebrand the app from "KnowYourGrape" to "Cata" with a refreshed visual identity. This plan covers the full transition: name updates, logo integration, color refinement, and UI polish.
+
+**Constraints:**
+- Logo: Option 10 (top-down wine glass with deep purple fill, white rim, subtle pink highlight)
+- Web app only for now (no App Store assets needed yet)
+- Dark mode only for MVP; light mode is future work
+- Keep what works: purple palette, generous spacing, rounded corners, system fonts
+
+---
+
+## Phase 1: Name Update (Immediate)
+
+Update all "KnowYourGrape" references to "Cata" throughout the app.
+
+### Files to Update (Complete Audit)
+
+**Client-side (UI-visible):**
+- `client/src/pages/HomeV2.tsx` - Lines 136, 332 (login screen, header)
+- `client/src/pages/SoloDashboard.tsx` - Lines 167, 241
+- `client/src/pages/UserDashboard.tsx` - Line 587
+- `client/src/pages/HomeTastings.tsx` - Line 94
+- `client/src/pages/SoloLogin.tsx` - Line 81
+- `client/src/components/layout/HomeLayout.tsx` - Line 88
+- `client/src/components/gateway/SelectionView.tsx` - Line 89
+- `client/index.html` - Page title, meta tags
+
+**Client-side (Technical):**
+- `client/src/hooks/useSessionPersistence.ts` - Line 26 (IndexedDB: 'KnowYourGrapeDB')
+- `client/public/manifest.json` - Lines 2-3 (PWA name)
+
+**Server-side:**
+- `server/routes.ts` - Any hardcoded app name in responses
+- `package.json` - Update `name` field if applicable
+
+**Marketing/Docs:**
+- `CLAUDE.md` - Update "Know Your Grape" description
+- `PRODUCT_ROADMAP.md` - Update vision statement
+- `PIVOT_RELEASE_NOTES.md` - Update app name
+
+### Research Insights: Name Update
+
+**Brand Constants Module (Recommended):**
+Create a single source of truth to prevent scattered string literals:
+
+```typescript
+// Proposed: client/src/lib/brand.ts
+export const BRAND = {
+  name: 'Cata',
+  tagline: 'Your personal sommelier',
+  dbName: 'CataDB',
+  meta: {
+    title: 'Cata - Wine Tasting',
+    description: 'Your personal sommelier for wine tasting experiences.',
+  },
+} as const;
+```
+
+**IndexedDB Migration (Critical):**
+The database name change in `useSessionPersistence.ts` requires migration:
+
+```typescript
+// Migration approach - check for old DB, migrate data, then delete
+const DB_NAME_OLD = 'KnowYourGrapeDB';
+const DB_NAME_NEW = 'CataDB';
+
+async function migrateDatabase() {
+  const oldDB = await openDB(DB_NAME_OLD);
+  if (oldDB) {
+    const data = await oldDB.getAll('sessions');
+    const newDB = await openDB(DB_NAME_NEW);
+    await newDB.putAll('sessions', data);
+    await deleteDB(DB_NAME_OLD);
+  }
+}
+```
+
+### Implementation
+
+```tsx
+// Before (HomeV2.tsx login screen):
+<h1 className="text-2xl font-bold text-white mb-2">
+  Know Your Grape
+</h1>
+<p className="text-white/60">Your personal wine journey</p>
+
+// After:
+<h1 className="text-2xl font-bold text-white mb-2">
+  Cata
+</h1>
+<p className="text-white/60">Your personal sommelier</p>
+```
+
+---
+
+## Phase 2: Background Simplification
+
+**Decision: Simplify the gradient background to let the logo breathe.**
+
+The current `bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900` creates visual noise. When the logo is added, a busy gradient will compete with it.
+
+### Research Insights: Dark Mode Best Practices
+
+**Background Color Validation:**
+- Near-black (#0f0a1a) is excellent for premium apps
+- Google Material Design recommends dark gray (#121212) over pure black
+- Adding subtle purple tint to dark grays is recommended for digital screens
+- Netflix, Spotify, and premium finance apps use similar approaches
+
+**Vertical vs Diagonal Gradient:**
+- Vertical (180deg) is better for content-focused apps - less visual "busy-ness"
+- Diagonal creates more movement but can compete with content
+- Wine tasting apps are content-focused - vertical is appropriate
+
+**Contrast Ratios (WCAG):**
+| Text Type | Minimum | Target |
+|-----------|---------|--------|
+| Body text | 4.5:1 | 7:1 |
+| Large text | 3:1 | 4.5:1 |
+
+**Text Colors for Dark Mode:**
+- Avoid pure white (#FFFFFF) - causes eye strain and "halation" effect
+- Use off-white: #E8E6ED or #F0F0F0 for primary text
+- Use #A0A0A0 to #B0B0B0 for secondary text
+
+**References:**
+- [LogRocket - Dark Mode Best Practices](https://blog.logrocket.com/ux-design/dark-mode-ui-design-best-practices-and-examples/)
+- [Toptal - Principles of Dark UI Design](https://www.toptal.com/designers/ui/dark-ui-design)
+- [WCAG Contrast Guidelines](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)
+
+### Recommendation
+
+```css
+/* Current (index.css) */
+--gradient-primary: linear-gradient(135deg, #581c87 0%, #1e1b4b 50%, #000000 100%);
+
+/* New: Simpler, darker, lets logo pop */
+--gradient-primary: linear-gradient(180deg, #0f0a1a 0%, #1a0f24 100%);
+
+/* Updated text colors for better readability */
+--text-primary: #E8E6ED;      /* Off-white, not pure white */
+--text-secondary: #A0A0A0;
+```
+
+### Implementation
+
+**File: `client/src/index.css`**
+```css
+:root {
+  /* Updated primary gradient - darker, simpler */
+  --gradient-primary: linear-gradient(180deg, #0f0a1a 0%, #1a0f24 100%);
+
+  /* Keep card gradient subtle */
+  --gradient-card: linear-gradient(135deg, rgba(88, 28, 135, 0.15) 0%, rgba(30, 27, 75, 0.1) 100%);
+
+  /* Future light mode support - adopt .dark class pattern */
+}
+
+.dark {
+  --gradient-primary: linear-gradient(180deg, #0f0a1a 0%, #1a0f24 100%);
+}
+```
+
+**Critical: Replace Inline Tailwind Gradients**
+
+The CSS variable change won't affect inline classes. Must replace:
+
+```tsx
+// Find and replace ALL instances of:
+className="... bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 ..."
+
+// With:
+className="... bg-gradient-primary ..."
+```
+
+Files with inline gradients to update:
+- `HomeV2.tsx` (lines 115, 124, 181)
+- `Gateway.tsx`
+- `SoloDashboard.tsx`
+- And others - grep for `from-slate-900`
+
+---
+
+## Phase 3: Color Refinement
+
+### Keep These Colors (They Work)
+
+| Purpose | Current | Decision |
+|---------|---------|----------|
+| Primary brand | `#7c3aed` (purple-500) | Keep - distinctive, wine-appropriate |
+| Dark variant | `#581c87` (purple-900) | Keep - good for depth |
+| Success | `#10b981` | Keep |
+| Warning | `#f59e0b` | Keep |
+| Error | `#ef4444` | Keep |
+
+### Accent Colors by Action Type
+
+The current accent system works well. Keep it:
+
+| Action Type | Gradient | Example |
+|-------------|----------|---------|
+| Solo tasting | `from-rose-500 to-pink-600` | "Record wine" button |
+| Learning | `from-indigo-500 to-purple-600` | "Journeys" button |
+| Group/social | `from-blue-500 to-purple-600` | "Join session" |
+| Host/create | `from-amber-500 to-orange-600` | "Host session" |
+
+### Cards: Simplify Glassmorphism
+
+### Research Insights: Glassmorphism 2025
+
+**Current State:**
+- Glassmorphism is still modern but requires thoughtful implementation
+- Apple's "Liquid Glass" has legitimized the trend
+- Risk: overuse can look dated quickly
+
+**Performance Impact (Critical):**
+| Blur Radius | Performance |
+|-------------|-------------|
+| 3-5px | Minimal impact, recommended for mobile |
+| 10-12px | Good balance, stays smooth |
+| 20px+ | Can impact frame rates on mobile |
+| 24px (current) | Falls into problematic category |
+
+**Recommendation: 12px (`backdrop-blur-md`) is the sweet spot.**
+
+**Alternatives Considered:**
+- Elevated surfaces (Apple approach) - slightly lighter shades for depth
+- Solid fill with subtle borders - simpler, better performance
+- Hybrid - blur for primary cards, solid for secondary
+
+**Performance Optimization:**
+```css
+/* Add for GPU acceleration */
+.glass-card {
+  will-change: backdrop-filter;
+  transform: translateZ(0);
+}
+
+/* Reduce blur on mobile */
+@media (max-width: 768px) {
+  .glass-card {
+    backdrop-filter: blur(8px);
+  }
+}
+
+/* Accessibility: respect user preferences */
+@media (prefers-reduced-transparency: reduce) {
+  .glass-card {
+    backdrop-filter: none;
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+```
+
+**References:**
+- [Josh W. Comeau - Backdrop Filter](https://www.joshwcomeau.com/css/backdrop-filter/)
+- [Apple HIG - Materials](https://developer.apple.com/design/human-interface-guidelines/materials)
+
+### Implementation
+
+```tsx
+// Current:
+className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-5 border border-white/20"
+
+// New: Less blur, more subtle
+className="bg-white/5 backdrop-blur-md rounded-2xl p-5 border border-white/10"
+```
+
+**Why:**
+- `backdrop-blur-md` (12px) instead of `xl` (24px) is ~49% faster
+- Single `bg-white/5` instead of gradient is cleaner
+- `border-white/10` instead of `/20` is less prominent
+
+---
+
+## Phase 4: Logo Integration
+
+Using Option 10: top-down wine glass view with deep purple wine surface, white/silver rim, and subtle pink highlight.
+
+### Research Insights: SVG Best Practices
+
+**Inline SVG vs `<img>` Tag:**
+| Use Case | Approach | Reason |
+|----------|----------|--------|
+| Splash/Login logo | Inline SVG component | Animation control, accessibility |
+| Header lockup | Inline SVG component | Responsive styling with Tailwind |
+| Decorative | `<img>` tag | Better caching |
+
+**Vite Configuration:**
+
+```typescript
+// vite.config.ts - add vite-plugin-svgr
+import svgr from 'vite-plugin-svgr';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    svgr({
+      svgrOptions: {
+        titleProp: true,  // Accessibility
+        ref: true,        // Animation support
+      },
+    }),
+  ],
+});
+```
+
+**Usage:**
+```tsx
+// Import as React component
+import LogoCata from '@/assets/logo-cata.svg?react';
+
+// Import as URL
+import logoUrl from '@/assets/logo-cata.svg';
+```
+
+**Accessibility Requirements (WCAG 1.1.1):**
+```tsx
+// Informative logo
+<LogoCata
+  role="img"
+  aria-label="Cata Logo"
+  className="w-20 h-20"
+/>
+
+// Logo inside link
+<a href="/" aria-label="Cata - Go to homepage">
+  <LogoCata aria-hidden="true" className="h-8" />
+</a>
+```
+
+**Responsive Sizing:**
+```tsx
+// Remove hardcoded width/height from SVG, use Tailwind
+<LogoCata className="w-20 h-20 md:w-24 md:h-24" />
+<LogoCataHorizontal className="h-8 w-auto" />
+```
+
+**References:**
+- [vite-plugin-svgr](https://github.com/pd4d10/vite-plugin-svgr)
+- [TPGi ARIA SVG Accessibility](https://www.tpgi.com/using-aria-enhance-svg-accessibility/)
+
+### Login Screen Logo
+
+```tsx
+// Current (HomeV2.tsx):
+<div className="w-20 h-20 mx-auto mb-4 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
+  <Wine className="w-10 h-10 text-white" />
+</div>
+
+// After:
+<img
+  src="/logo-cata.svg"
+  alt="Cata"
+  width={80}
+  height={80}
+  className="w-20 h-20 mx-auto mb-4"
+/>
+```
+
+### Header Logo
+
+```tsx
+// Current:
+<div className="flex items-center gap-3">
+  <Wine className="w-6 h-6 text-purple-400" />
+  <span className="text-white font-semibold">Know Your Grape</span>
+</div>
+
+// After:
+<img
+  src="/logo-cata-horizontal.svg"
+  alt="Cata"
+  className="h-8 w-auto"
+/>
+```
+
+### Logo Assets Needed
+
+| Asset | Use Case | Notes |
+|-------|----------|-------|
+| `logo-cata.svg` | Splash, login | Square, full detail |
+| `logo-cata-horizontal.svg` | Header | Icon + "cata" wordmark |
+| `favicon.svg` | Browser tab | Simplified for 32x32 |
+
+**Favicon Setup (index.html):**
+```html
+<head>
+  <!-- SVG favicon with dark mode support -->
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <!-- PNG fallback -->
+  <link rel="icon" href="/favicon-48.png" sizes="48x48" type="image/png">
+</head>
+```
+
+**First step:** Vectorize Option 10 in Figma or Illustrator to create clean SVG.
+
+### Splash Screen
+
+### Research Insights: Splash Screens
+
+**When to Use:**
+- App requires critical initialization (auth checks, config loading)
+- Need to establish brand identity on first launch
+- Use skeleton screens instead for page-level data loading
+
+**Animation Timing:**
+| Context | Duration |
+|---------|----------|
+| Entrance animation | 200-300ms |
+| Exit animation | 150-200ms (faster than entrance) |
+| Total display | Do not exceed 1000ms |
+
+**Recommended: Fade out (not slide) for exit.**
+
+**Performance Option: CSS Animation**
+Consider CSS instead of Framer Motion for 25KB bundle savings:
+
+```css
+@keyframes splash-fade-in {
+  from { opacity: 0; transform: scale(0.8); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.splash-logo {
+  animation: splash-fade-in 0.3s ease-out forwards;
+}
+```
+
+**Preventing Flash of Content:**
+```tsx
+function App() {
+  const [isReady, setIsReady] = useState(false);
+  const [showSplash, setShowSplash] = useState(true);
+
+  useEffect(() => {
+    async function initialize() {
+      await checkAuthState();
+      setIsReady(true);
+      // Small delay for smooth transition
+      await new Promise(r => setTimeout(r, 300));
+      setShowSplash(false);
+    }
+    initialize();
+  }, []);
+
+  return (
+    <>
+      <AnimatePresence>
+        {showSplash && <SplashScreen key="splash" />}
+      </AnimatePresence>
+      {isReady && <MainApp />}
+    </>
+  );
+}
+```
+
+**References:**
+- [NN/g Animation Duration](https://www.nngroup.com/articles/animation-duration/)
+- [Android Splash Screen Guidelines](https://developer.android.com/develop/ui/views/launch/splash-screen)
+
+### Implementation
+
+```tsx
+// client/src/components/SplashScreen.tsx
+import { motion } from 'framer-motion';
+
+const logoAnimation = {
+  initial: { opacity: 0, scale: 0.8 },
+  animate: { opacity: 1, scale: 1 },
+  transition: { duration: 0.3, ease: [0.4, 0, 0.2, 1] },
+} as const;
+
+export function SplashScreen() {
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 bg-gradient-primary flex items-center justify-center"
+      initial={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+    >
+      <motion.img
+        src="/logo-cata.svg"
+        alt="Cata"
+        className="w-24 h-24"
+        {...logoAnimation}
+      />
+    </motion.div>
+  );
+}
+```
+
+---
+
+## Implementation Order
+
+1. [ ] Name update - replace all "KnowYourGrape" with "Cata" (12+ files)
+2. [ ] IndexedDB migration - handle database rename
+3. [ ] Background simplification - new gradient + replace inline Tailwind
+4. [ ] Card simplification - reduce glassmorphism
+5. [ ] Integrate logo (Option 10 - top-down wine glass)
+6. [ ] Update login screen with logo
+7. [ ] Update headers throughout app
+8. [ ] Create splash screen
+9. [ ] PWA manifest update + cache busting
+10. [ ] Documentation updates
+
+---
+
+## Files to Modify (Complete)
+
+| File | Phase | Changes |
+|------|-------|---------|
+| `client/src/index.css` | 2-3 | Gradient, card styles, text colors |
+| `client/src/pages/HomeV2.tsx` | 1-4 | Name, backgrounds, cards, logo |
+| `client/src/pages/SoloDashboard.tsx` | 1 | Name update (2 locations) |
+| `client/src/pages/UserDashboard.tsx` | 1 | Name update |
+| `client/src/pages/HomeTastings.tsx` | 1 | Name update |
+| `client/src/pages/SoloLogin.tsx` | 1 | Name update |
+| `client/src/components/layout/HomeLayout.tsx` | 1 | Name update |
+| `client/src/components/gateway/SelectionView.tsx` | 1 | Name update |
+| `client/src/hooks/useSessionPersistence.ts` | 1 | IndexedDB migration |
+| `client/public/manifest.json` | 1 | PWA name, icons |
+| `client/index.html` | 1, 4 | Title, meta, favicon |
+| `vite.config.ts` | 4 | Add vite-plugin-svgr |
+| `CLAUDE.md` | 1 | App description |
+| `PRODUCT_ROADMAP.md` | 1 | Vision statement |
+
+---
+
+## Acceptance Criteria
+
+### Phase 1 (Name)
+- [ ] No "KnowYourGrape" text visible anywhere in app
+- [ ] Page title shows "Cata"
+- [ ] Login screen says "Cata"
+- [ ] Headers say "Cata"
+- [ ] IndexedDB migrated without data loss
+
+### Phase 2 (Background)
+- [ ] Background is darker and simpler
+- [ ] All inline Tailwind gradients replaced with CSS variable
+- [ ] Text contrast meets WCAG 4.5:1 minimum
+- [ ] Overall feel is more premium/sophisticated
+
+### Phase 3 (Colors)
+- [ ] Purple still feels like primary brand color
+- [ ] Action buttons are still distinct by type
+- [ ] Cards are less "glassy", more subtle
+- [ ] Blur reduced to 12px on desktop, 8px on mobile
+
+### Phase 4 (Logo)
+- [ ] Logo appears on login screen with proper alt text
+- [ ] Logo appears in headers
+- [ ] Logo scales appropriately on different screens
+- [ ] Splash screen shows logo with fade animation
+- [ ] Favicon updated
+
+---
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Logo needs tweaks after seeing it in-app | Low | Logo is SVG, easy to swap out |
+| Background too dark | Medium | Test on multiple devices, adjust opacity if needed |
+| Glassmorphism reduction loses personality | Low | Keep subtle blur, don't go fully flat |
+| Inline gradients bypass CSS variable changes | High | Audit and replace all inline gradients |
+| IndexedDB data loss on rename | High | Implement migration before renaming |
+| PWA cache serves old brand | Medium | Bump service worker cache version |
+
+---
+
+## Performance Summary
+
+| Change | Impact |
+|--------|--------|
+| Backdrop-blur 24px → 12px | ~49% faster blur calculation |
+| Gradient 3-color → 2-color | Marginal (~0.1-0.5ms per paint) |
+| SVG logo vs React component | 1-2KB bundle reduction |
+| CSS animation vs Framer Motion | 25KB savings (if applicable) |
+
+---
+
+## References
+
+### Internal
+- `BRAND.md` - Full brand guidelines with logo exploration learnings
+- `plans/feat-dashboard-redesign-v2.md` - UI design vision (some overlap)
+- `client/src/index.css` - Current CSS variables
+- `client/src/pages/HomeV2.tsx` - Main UI to update
+
+### External
+- [LogRocket - Dark Mode Best Practices](https://blog.logrocket.com/ux-design/dark-mode-ui-design-best-practices-and-examples/)
+- [Toptal - Principles of Dark UI Design](https://www.toptal.com/designers/ui/dark-ui-design)
+- [WCAG Contrast Guidelines](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)
+- [Josh W. Comeau - Backdrop Filter](https://www.joshwcomeau.com/css/backdrop-filter/)
+- [Apple HIG - Dark Mode](https://developer.apple.com/design/human-interface-guidelines/dark-mode)
+- [vite-plugin-svgr](https://github.com/pd4d10/vite-plugin-svgr)
+- [TPGi ARIA SVG Accessibility](https://www.tpgi.com/using-aria-enhance-svg-accessibility/)
+- [NN/g Animation Duration](https://www.nngroup.com/articles/animation-duration/)

--- a/plans/fix-homev2-ux-issues.md
+++ b/plans/fix-homev2-ux-issues.md
@@ -1,0 +1,509 @@
+# Fix HomeV2 UX Issues: Navigation, Equal Prominence, and Group History
+
+## Enhancement Summary
+
+**Deepened on:** 2026-01-21
+**Research agents used:** 8 (TypeScript reviewer, Code simplicity reviewer, Architecture strategist, Frontend races reviewer, Performance oracle, Pattern recognition specialist, Framework docs researcher, Best practices researcher)
+
+### Key Improvements
+1. **Simplified navigation fix**: Use Option B (direct route) - just remove redirect, 2 lines changed
+2. **Type safety enhancements**: Export TabKey from single source, avoid `any[]` types
+3. **Performance optimizations**: Add staleTime/gcTime to queries, prefetch on tab hover
+4. **Race condition mitigations**: Include tab in query key, handle rapid switching
+
+### New Considerations Discovered
+- HomeV2.tsx at 1,253 lines is a code smell - consider extracting tab contents to separate files
+- Duplicate TabKey type definitions between HomeV2.tsx and BottomNav.tsx need consolidation
+- The wildcard route pattern with manual path inspection is fragile - consider parameterized routes
+
+---
+
+## Overview
+
+Three issues were identified in the newly deployed Three Pillars HomeV2 interface:
+
+1. **Learning Journeys Navigation Bug** - Clicking "Learning Journeys" button doesn't navigate to the journeys browser; it stays on Solo tab
+2. **Unequal Prominence** - Solo Tasting and Learning Journeys should be equally weighted entry points, not one "sandwiched" below the other
+3. **Missing Group Tasting History** - Group tab shows "Your group tasting history will appear here" even for users with group tasting data
+
+## Problem Analysis
+
+### Issue 1: Learning Journeys Navigation Bug
+
+**Root Cause:** The Learning Journeys button navigates to `/journeys` (line 408 in HomeV2.tsx):
+```tsx
+onClick={() => setLocation("/journeys")}
+```
+
+App.tsx redirects `/journeys` to `/home/journeys`:
+```tsx
+<Route path="/journeys">
+  <Redirect to="/home/journeys" />
+</Route>
+```
+
+But `/home/journeys` is matched by `<Route path="/home/:rest*" component={HomeV2} />`, which renders HomeV2. Inside HomeV2, `getActiveTab()` only checks for `/group` or `/dashboard` - anything else returns `"solo"`:
+```tsx
+const getActiveTab = (): TabKey => {
+  if (location.includes("/group")) return "group";
+  if (location.includes("/dashboard")) return "dashboard";
+  return "solo"; // ← /home/journeys falls through to solo!
+};
+```
+
+**Result:** User clicks Learning Journeys → redirects to `/home/journeys` → HomeV2 renders → but still shows Solo tab.
+
+### Research Insights: Navigation
+
+**Simplicity reviewer verdict: Option B is significantly simpler.**
+
+| Aspect | Option A (Embedded Tab) | Option B (Direct Route) |
+|--------|-------------------------|------------------------|
+| Type changes | Add "journeys" to TabKey | None |
+| New component | JourneysTabContent (duplicate) | None |
+| Lines of code | +150-250 | -4 lines |
+| Complexity | High | Low |
+
+**Architecture strategist verdict: Keep journeys separate.**
+- Journeys represent a different navigation depth (Journey → Chapters → Tasting)
+- Tabs should represent peer-level views, not entry points into deep flows
+- Mobile UX research suggests 3-5 tabs maximum
+
+**Wouter routing best practice:**
+- The wildcard + manual path inspection pattern is fragile
+- Consider using parameterized routes: `<Route path="/home/:tab?" component={HomeV2} />`
+
+### Issue 2: Unequal Prominence - Solo vs Journeys
+
+**Current Layout (Solo Tab):**
+```
+[Header]
+[Solo Tastings title]
+[Start New Tasting] ← BIG gradient button, most prominent
+[Continue Journey card] ← only if in progress
+[Learning Journeys] ← smaller, secondary-looking button
+[Taste Profile]
+[Recent Tastings]
+```
+
+**Problem:** Learning Journeys looks like a secondary option tucked under Solo Tasting. But these are **two equally important paths** users should choose from.
+
+### Research Insights: Equal Prominence UI
+
+**Best practices for dual equally-weighted CTAs:**
+- Side-by-side 2-column grid creates visual symmetry that reinforces equal weight
+- Both options visible simultaneously without scrolling
+- Use CSS Grid: `grid-template-columns: repeat(2, minmax(0, 1fr))`
+
+**Color strategy for equal weight:**
+- Same structure, different colors of equal saturation
+- Wine context recommendation: Burgundy (#722F37) + Deep Teal (#2E5851)
+- Both colors suggest sophistication with equal visual weight
+
+**Touch target requirements (WCAG):**
+- Minimum 48x48dp (Android Material Design)
+- Card height: 140-160px minimum
+- Gap between cards: 16px
+
+**Animation for equality:**
+- Both cards should animate simultaneously (not staggered)
+- Mirrored animations reinforce equality
+- Hover/press: subtle scale (1.02/0.98), 150-200ms transition
+
+### Issue 3: Missing Group Tasting History
+
+**Root Cause:** The Group Tab Content (lines 826-837) shows a static placeholder:
+```tsx
+{/* Group History - placeholder */}
+<div>
+  <h2 className="text-lg font-semibold text-white mb-4">
+    Recent Group Tastings
+  </h2>
+  <div className="text-center py-12 ...">
+    <Users className="w-12 h-12 text-white/30 mx-auto mb-4" />
+    <p className="text-white/60">
+      Your group tasting history will appear here
+    </p>
+  </div>
+</div>
+```
+
+**The data exists!** The API endpoint `/api/dashboard/:email/history` fetches combined solo + group history using `storage.getUserTastingHistory()`. The Dashboard tab even shows the correct counts (10 Total, 4 Solo, 6 Group from Image 4).
+
+But the Group tab **never calls this API** - it just shows a hardcoded empty state.
+
+### Research Insights: Data Fetching
+
+**TypeScript reviewer requirements:**
+```typescript
+// BAD - No error handling, uses any[]
+const { data: historyData } = useQuery<any[]>({...});
+
+// GOOD - Proper types and error handling
+interface GroupTasting {
+  sessionId: string;
+  packageName: string;
+  winesTasted: number;
+  startedAt: string;
+  source: 'group' | 'solo';
+}
+
+const { data: historyData, isLoading, error } = useQuery<GroupTasting[]>({
+  queryKey: ['dashboard', 'history', user.email],
+  queryFn: async () => {
+    const response = await apiRequest(...);
+    if (!response.ok) {
+      if (response.status === 404) return []; // Expected for new users
+      throw new Error("Failed to fetch history");
+    }
+    return response.json();
+  },
+  enabled: !!user.email,
+  staleTime: 5 * 60 * 1000, // 5 minutes
+});
+```
+
+**Performance oracle recommendations:**
+- Add `staleTime: 5 * 60 * 1000` (5 minutes)
+- Add `gcTime: 30 * 60 * 1000` (30 minutes)
+- Add `enabled: activeTab === 'group'` to only fetch when tab is active
+- Implement prefetch on tab hover for instant perceived loading
+
+**Race condition mitigations:**
+- Include `activeTab` in query key to prevent stale data on rapid tab switching
+- Use `useMemo` for derived data (filtered group tastings)
+
+---
+
+## Proposed Solution
+
+### Fix 1: Learning Journeys Navigation (SIMPLIFIED)
+
+**Use Option B: Direct Route (2 lines changed)**
+
+1. **Remove the redirect** in App.tsx (lines 57-59):
+```tsx
+// DELETE these lines:
+<Route path="/journeys">
+  <Redirect to="/home/journeys" />
+</Route>
+```
+
+2. **Keep the existing route** for JourneyBrowser:
+```tsx
+// This already exists and will now work
+<Route path="/journeys" component={JourneyBrowser} />
+```
+
+3. **Update JourneyBrowser back button** to return to `/home`:
+```tsx
+// In JourneyBrowser.tsx, update back navigation
+onClick={() => setLocation("/home")} // Instead of "/"
+```
+
+**Why this is better:**
+- No code duplication
+- No new components needed
+- JourneyBrowser already has filtering, grid layout, etc.
+- Journey detail pages (`/journeys/:id`) already work
+
+### Fix 2: Equal Prominence for Solo Tasting vs Learning Journeys
+
+**Design Pattern:** Use the same **two-column grid** pattern already used successfully in the Group tab.
+
+**Proposed Solo Tab Layout:**
+
+```
+[Header]
+["What would you like to do today?"]
+
++-------------------+-------------------+
+|  [Wine Icon]      |  [Graduate Cap]   |
+|  Solo Tasting     |  Learning         |
+|  Record your      |  Journeys         |
+|  experience       |  Guided education |
++-------------------+-------------------+
+
+[Continue Journey card] ← only if in progress
+
+[Your Taste Profile summary]
+
+[Recent Solo Tastings list]
+```
+
+**Implementation with research insights:**
+
+```tsx
+{/* Two Primary Actions - Equal Weight */}
+<div className="grid grid-cols-2 gap-4">
+  {/* Solo Tasting Card */}
+  <motion.button
+    onClick={() => setLocation("/tasting/new")}
+    initial={{ opacity: 0, y: 20 }}
+    animate={{ opacity: 1, y: 0 }}
+    transition={{ duration: 0.3 }}
+    whileHover={{ scale: 1.02 }}
+    whileTap={{ scale: 0.98 }}
+    className="bg-gradient-to-br from-rose-500 to-pink-600 rounded-2xl p-6 text-left min-h-[160px] focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+  >
+    <div className="w-12 h-12 bg-white/20 rounded-full flex items-center justify-center mb-4">
+      <Wine className="w-6 h-6 text-white" />
+    </div>
+    <h3 className="text-xl font-semibold text-white mb-2">Solo Tasting</h3>
+    <p className="text-white/70 text-sm">Record your wine experience</p>
+  </motion.button>
+
+  {/* Learning Journeys Card - EQUAL styling, different color */}
+  <motion.button
+    onClick={() => setLocation("/journeys")}
+    initial={{ opacity: 0, y: 20 }}
+    animate={{ opacity: 1, y: 0 }}
+    transition={{ duration: 0.3 }}
+    whileHover={{ scale: 1.02 }}
+    whileTap={{ scale: 0.98 }}
+    className="bg-gradient-to-br from-indigo-500 to-purple-600 rounded-2xl p-6 text-left min-h-[160px] focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+  >
+    <div className="w-12 h-12 bg-white/20 rounded-full flex items-center justify-center mb-4">
+      <GraduationCap className="w-6 h-6 text-white" />
+    </div>
+    <h3 className="text-xl font-semibold text-white mb-2">Learning Journeys</h3>
+    <p className="text-white/70 text-sm">Structured wine education</p>
+  </motion.button>
+</div>
+```
+
+**Key design decisions:**
+- Same height (`min-h-[160px]`) ensures equal visual weight
+- Simultaneous animation (same `transition` props) reinforces equality
+- Different but equally saturated gradients differentiate without hierarchy
+- Focus-visible ring for accessibility
+
+### Fix 3: Fetch and Display Group Tasting History
+
+**Implementation with all research insights:**
+
+```tsx
+// Define proper types (NOT any[])
+interface GroupTasting {
+  sessionId: string;
+  packageName: string;
+  winesTasted: number;
+  startedAt: string;
+  completedAt: string | null;
+  source: 'group' | 'solo';
+  userScore: string;
+  groupScore: string;
+}
+
+// In GroupTabContent:
+const queryClient = useQueryClient();
+
+// Optimized query with proper caching
+const { data: historyData, isLoading: historyLoading } = useQuery<GroupTasting[]>({
+  queryKey: ['dashboard', 'history', user.email, 'group'], // Include tab for cache isolation
+  queryFn: async () => {
+    const response = await apiRequest(
+      "GET",
+      `/api/dashboard/${encodeURIComponent(user.email)}/history?limit=10`,
+      null
+    );
+    if (!response.ok) {
+      if (response.status === 404) return [];
+      throw new Error("Failed to fetch history");
+    }
+    const data = await response.json();
+    return data.filter((t: GroupTasting) => t.source === 'group');
+  },
+  enabled: !!user.email,
+  staleTime: 5 * 60 * 1000, // 5 minutes - data considered fresh
+  gcTime: 30 * 60 * 1000,   // 30 minutes - keep in cache
+  refetchOnWindowFocus: false,
+});
+
+// Prefetch on tab hover (add to BottomNav)
+const prefetchGroupHistory = () => {
+  queryClient.prefetchQuery({
+    queryKey: ['dashboard', 'history', user.email, 'group'],
+    queryFn: fetchGroupHistory,
+    staleTime: 5 * 60 * 1000,
+  });
+};
+```
+
+**Render with proper loading/error states:**
+
+```tsx
+{/* Recent Group Tastings */}
+<div>
+  <h2 className="text-lg font-semibold text-white mb-4">
+    Recent Group Tastings
+  </h2>
+
+  {historyLoading ? (
+    <div className="flex justify-center py-8">
+      <Loader2 className="w-6 h-6 text-purple-400 animate-spin" />
+    </div>
+  ) : historyData && historyData.length > 0 ? (
+    <div className="space-y-3">
+      {historyData.slice(0, 5).map((tasting) => (
+        <motion.div
+          key={tasting.sessionId}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          onClick={() => setLocation(`/dashboard/${encodeURIComponent(user.email)}/tasting/${tasting.sessionId}`)}
+          className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-xl p-4 border border-white/20 cursor-pointer hover:bg-white/15 transition-colors"
+        >
+          <div className="flex items-start justify-between">
+            <div className="flex-1 min-w-0">
+              <h3 className="text-white font-medium truncate">
+                {tasting.packageName}
+              </h3>
+              <div className="flex flex-wrap gap-2 text-sm text-white/60 mt-1">
+                <span>{tasting.winesTasted} wines</span>
+                <span>•</span>
+                <span>{new Date(tasting.startedAt).toLocaleDateString()}</span>
+              </div>
+            </div>
+            <ChevronRight className="w-5 h-5 text-white/40" />
+          </div>
+        </motion.div>
+      ))}
+    </div>
+  ) : (
+    <div className="text-center py-12 bg-gradient-to-br from-white/5 to-white/0 rounded-2xl border border-white/10">
+      <Users className="w-12 h-12 text-white/30 mx-auto mb-4" />
+      <p className="text-white/60">
+        Your group tasting history will appear here
+      </p>
+    </div>
+  )}
+</div>
+```
+
+---
+
+## Acceptance Criteria
+
+### Navigation
+- [ ] Clicking "Learning Journeys" button navigates to JourneyBrowser page
+- [ ] JourneyBrowser "Back" button returns to `/home`
+- [ ] No redirect loop or stuck navigation
+
+### Equal Prominence
+- [ ] Solo Tasting and Learning Journeys appear as two equal-sized cards side by side
+- [ ] Both cards have similar gradient styling and visual weight
+- [ ] Both cards animate simultaneously (not staggered)
+- [ ] On mobile (single column), both cards have equal height and styling
+- [ ] Neither option appears "primary" over the other
+- [ ] Touch targets meet WCAG AA (minimum 48x48dp)
+
+### Group History
+- [ ] Users with group tasting history see their past sessions listed
+- [ ] Each group tasting shows: package name, date, wines tasted count
+- [ ] Tapping a group tasting navigates to `/dashboard/:email/tasting/:sessionId`
+- [ ] Empty state only shows when user has zero group tastings
+- [ ] Loading spinner shown while fetching
+- [ ] Data is cached for 5 minutes (staleTime)
+
+### General
+- [ ] All three tabs (Solo, Group, Dashboard) continue to work
+- [ ] Tab switching remains smooth with proper animations
+- [ ] No race conditions on rapid tab switching
+- [ ] No regression in existing features
+
+---
+
+## Implementation Plan
+
+### Phase 1: Fix Navigation Bug (2 lines)
+
+**File:** `client/src/App.tsx`
+
+**Change:** Delete the redirect (lines 57-59):
+```tsx
+// DELETE:
+<Route path="/journeys">
+  <Redirect to="/home/journeys" />
+</Route>
+```
+
+**File:** `client/src/pages/JourneyBrowser.tsx`
+
+**Change:** Update back button to go to `/home` instead of `/`.
+
+### Phase 2: Equal Prominence UI (~15 lines)
+
+**File:** `client/src/pages/HomeV2.tsx`
+
+**Replace** the current two separate buttons (lines 340-428) with the two-column grid layout shown above.
+
+**Key changes:**
+- Wrap in `<div className="grid grid-cols-2 gap-4">`
+- Make both buttons equal height (`min-h-[160px]`)
+- Use equally-saturated gradients
+- Animate both simultaneously
+
+### Phase 3: Group History Implementation (~40 lines)
+
+**File:** `client/src/pages/HomeV2.tsx`
+
+**Change 1:** Add type definition at top of file:
+```tsx
+interface GroupTasting {
+  sessionId: string;
+  packageName: string;
+  winesTasted: number;
+  startedAt: string;
+  source: 'group' | 'solo';
+}
+```
+
+**Change 2:** Add history query to `GroupTabContent` (after existing queries).
+
+**Change 3:** Replace placeholder (lines 826-837) with actual tasting list.
+
+---
+
+## Files to Modify
+
+| File | Changes | Lines |
+|------|---------|-------|
+| `client/src/App.tsx` | Remove redirect | -3 |
+| `client/src/pages/JourneyBrowser.tsx` | Update back button | ~1 |
+| `client/src/pages/HomeV2.tsx` | Grid layout + history fetch | ~55 |
+
+**Total: ~55 lines changed**
+
+---
+
+## Technical Debt to Address (Future)
+
+From the architecture and TypeScript reviews:
+
+1. **Extract tab contents to separate files** - HomeV2.tsx is 1,253 lines
+2. **Consolidate TabKey type** - Currently duplicated in HomeV2.tsx and BottomNav.tsx
+3. **Fix `any[]` usage** - Line 290 uses `any[]` for journeys data
+4. **Consider parameterized routes** - Replace wildcard pattern with `/home/:tab?`
+
+---
+
+## References
+
+### Internal
+- `client/src/pages/HomeV2.tsx:407-428` - Current Learning Journeys button
+- `client/src/pages/HomeV2.tsx:759-795` - Group tab two-column grid pattern to reuse
+- `client/src/pages/HomeV2.tsx:826-837` - Current group history placeholder
+- `server/routes/dashboard.ts:89-109` - History API endpoint
+- `server/storage.ts:5178-5299` - getUserTastingHistory implementation
+
+### External
+- [TanStack Query - Conditional Fetching](https://tanstack.com/query/v5/docs/framework/react/guides/dependent-queries)
+- [Framer Motion - AnimatePresence](https://www.framer.com/motion/animate-presence/)
+- [WCAG 2.5.8 - Touch Target Size](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html)
+- [Design Monks - Two Primary Buttons UI](https://www.designmonks.co/blog/show-two-primary-buttons-ui)
+
+### User Feedback Images
+- Image 1: Gateway.tsx showing equal-weight options
+- Image 2: Current Solo tab with sandwiched Learning Journeys
+- Image 3: Group tab with missing history
+- Image 4: Dashboard showing correct stats (10 Total, 4 Solo, 6 Group)

--- a/plans/fix-logo-and-gateway.md
+++ b/plans/fix-logo-and-gateway.md
@@ -1,0 +1,118 @@
+# Fix Logo Readability & Gateway Branding
+
+## Overview
+
+Two issues with the brand overhaul:
+1. **Gateway page (`/`)** still shows old side-view Wine icon from Lucide
+2. **New logo doesn't read as "wine glass"** - looks like a purple orb/sphere
+
+## Problem Analysis
+
+### Gateway Issue
+The `SelectionView.tsx` component still uses `<Wine />` from Lucide icons instead of the new logo. This was missed in the brand overhaul.
+
+**Files to update:**
+- `client/src/components/gateway/SelectionView.tsx` - Line 76 uses `<Wine />` icon
+
+### Logo Issue
+The current SVG attempts to show a top-down wine glass, but without visual depth cues, it reads as a solid purple circle. The concept works in the BRAND.md description, but the execution lacks the visual elements that would make it recognizable.
+
+**Current logo problems:**
+- No sense of depth or "looking into a glass"
+- Rim is too thin to read as a glass edge
+- Wine surface looks like a solid ball, not liquid
+- Missing the distinctive perspective that would say "wine glass"
+
+## Options for Logo Fix
+
+### Option A: Add Visual Depth to Current Concept (Recommended)
+Keep the top-down wine glass concept but make it actually read as a glass:
+
+**Changes needed:**
+- Add a darker inner ring to suggest depth/bowl
+- Add a subtle reflection/sheen that suggests liquid surface
+- Make the rim more prominent (thicker stroke or double ring)
+- Add a small stem hint at bottom (optional, subtle)
+
+```svg
+<!-- Concept: Thicker rim, visible bowl depth, liquid surface effect -->
+<circle cx="50" cy="50" r="46" fill="none" stroke="#e8e6ed" stroke-width="6"/> <!-- Thicker rim -->
+<circle cx="50" cy="50" r="38" fill="#1a0a2e"/> <!-- Dark bowl/depth -->
+<circle cx="50" cy="50" r="34" fill="url(#wineGradient)"/> <!-- Wine surface, smaller -->
+<ellipse cx="50" cy="45" rx="20" ry="8" fill="rgba(255,255,255,0.15)"/> <!-- Oval highlight = liquid surface -->
+```
+
+**Pros:** Preserves original concept, minimal rework
+**Cons:** May still be abstract for some users
+
+### Option B: Hybrid View (Slight Angle)
+Instead of pure top-down, show a slight 3/4 view that reveals the glass shape:
+
+**Changes needed:**
+- Create new SVG with elliptical rim (not perfect circle)
+- Show hint of glass bowl curve
+- Wine surface visible but with perspective
+
+**Pros:** Much more recognizable as wine glass
+**Cons:** More complex SVG, deviates from original concept
+
+### Option C: Return to Side-View Glass (Different Style)
+Use a side-view wine glass but make it distinctive/premium:
+
+**Changes needed:**
+- Create minimal geometric side-view glass
+- Fill with purple gradient (wine)
+- Keep it simple and iconic (like the old Lucide icon but branded)
+
+**Pros:** Immediately recognizable as wine
+**Cons:** "Every wine app does this" per BRAND.md
+
+### Option D: Keep Current + Add Context
+Keep the abstract logo but always show it with the "Cata" wordmark:
+
+**Changes needed:**
+- Never show logo alone
+- Always pair with "Cata" text
+- Let the abstract mark become recognizable through branding
+
+**Pros:** Brand builds over time
+**Cons:** Current state looks generic/unfinished
+
+## Recommendation
+
+**Option A** is the fastest fix - we can enhance the current SVG to have more depth without changing the concept. If that doesn't work, we move to **Option B**.
+
+## Implementation Plan
+
+### Phase 1: Fix Gateway (5 min)
+1. Update `SelectionView.tsx` to use logo image instead of Lucide Wine icon
+
+### Phase 2: Enhance Logo SVG (15 min)
+1. Redesign `logo-cata.svg` with:
+   - Thicker, more prominent rim
+   - Inner shadow/depth ring
+   - Liquid surface highlight (elliptical, not circular)
+   - Optional: tiny stem hint at bottom
+2. Update `logo-cata-horizontal.svg` with same changes
+3. Update `favicon.svg` (simplified version)
+
+### Phase 3: Test & Iterate
+1. View in browser at multiple sizes
+2. Get user feedback
+3. Adjust as needed
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `client/src/components/gateway/SelectionView.tsx` | Replace `<Wine />` with logo image |
+| `client/public/logo-cata.svg` | Enhance with depth |
+| `client/public/logo-cata-horizontal.svg` | Match main logo changes |
+| `client/public/favicon.svg` | Simplified version |
+
+## Acceptance Criteria
+
+- [ ] Gateway page shows new Cata logo, not Lucide Wine icon
+- [ ] Logo reads as "wine glass" not "purple sphere"
+- [ ] Logo works at all sizes (favicon to splash screen)
+- [ ] User confirms improvement

--- a/plans/fix-pre-existing-typescript-errors.md
+++ b/plans/fix-pre-existing-typescript-errors.md
@@ -1,0 +1,209 @@
+# Fix Pre-existing TypeScript Errors
+
+## Overview
+
+The codebase has 8 pre-existing TypeScript errors across 6 files that need to be resolved to achieve a clean type check. These are straightforward type safety issues that can be fixed with minimal code changes.
+
+## Problem Statement
+
+Running `npm run check` produces 8 TypeScript errors:
+
+1. **modern-button.tsx:52** - Framer Motion prop type conflict with React button props
+2. **video-player.tsx:257-258** - Safari webkit fullscreen API not in TypeScript types
+3. **PackageEditor.tsx:276** - Untyped `error` in catch block
+4. **SoloTastingDetail.tsx:327** - `unknown` type not assignable to `ReactNode`
+5. **TastingCompletion.tsx:132** - Optional `style`/`regionCharacter` fields vs required in interface
+6. **TastingDetailView.tsx:138** - `userParticipant` not in `TastingDetailData` interface
+7. **server/routes.ts:1096** - `string | null` passed where `string` required
+
+## Proposed Solution
+
+Fix each error with targeted, minimal changes.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `npm run check` exits with code 0 (no errors)
+- [ ] All fixes are type-safe (no `any` escape hatches unless absolutely necessary)
+- [ ] Existing functionality unchanged
+- [ ] No new runtime errors introduced
+
+---
+
+## Implementation Details
+
+### 1. modern-button.tsx:52 - Framer Motion Props Conflict
+
+**Problem:** Spreading `...props` from `React.ButtonHTMLAttributes<HTMLButtonElement>` onto `motion.button` causes conflict because `onDrag` has different signatures.
+
+**Fix:** Exclude conflicting event handlers from the spread.
+
+```typescript
+// client/src/components/ui/modern-button.tsx
+
+// Change the props interface or exclude problematic props
+const { onDrag, onDragStart, onDragEnd, ...safeProps } = props;
+
+// Then spread safeProps instead of props
+<motion.button {...safeProps}>
+```
+
+**Alternative:** Use `Omit` in the interface to exclude conflicting props:
+```typescript
+interface ModernButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onDrag' | 'onDragStart' | 'onDragEnd'> {
+```
+
+---
+
+### 2. video-player.tsx:257-258 - Safari Webkit Fullscreen
+
+**Problem:** `webkitEnterFullscreen` is a Safari-specific API not in standard TypeScript HTMLVideoElement type.
+
+**Fix:** Extend the type or use type assertion.
+
+```typescript
+// client/src/components/ui/video-player.tsx:256-261
+
+// Option A: Type assertion with interface extension
+interface WebkitVideoElement extends HTMLVideoElement {
+  webkitEnterFullscreen?: () => void;
+}
+
+const videoEl = videoRef.current as WebkitVideoElement;
+if (videoEl?.webkitEnterFullscreen) {
+  videoEl.webkitEnterFullscreen();
+  // ...
+}
+
+// Option B: Direct type assertion (simpler)
+if ((videoEl as any).webkitEnterFullscreen) {
+  (videoEl as any).webkitEnterFullscreen();
+}
+```
+
+---
+
+### 3. PackageEditor.tsx:276 - Untyped Error
+
+**Problem:** In catch blocks, `error` is type `unknown` in TypeScript 4.4+.
+
+**Fix:** Type narrow the error.
+
+```typescript
+// client/src/pages/PackageEditor.tsx:272-279
+
+} catch (error) {
+  console.error('Failed to update comparable state:', error);
+  toast({
+    title: "Error updating comparable state",
+    description: error instanceof Error ? error.message : "Unknown error",
+    variant: "destructive"
+  });
+}
+```
+
+---
+
+### 4. SoloTastingDetail.tsx:327 - Unknown to ReactNode
+
+**Problem:** Some value of type `unknown` is being rendered directly.
+
+**Fix:** Need to examine the specific code context and add type narrowing or casting.
+
+```typescript
+// Likely fix pattern:
+// Change: {someUnknownValue}
+// To: {String(someUnknownValue)} or {someUnknownValue as string}
+```
+
+*Note: Need to read more context around line 327 to determine exact fix.*
+
+---
+
+### 5. TastingCompletion.tsx:132 - Optional vs Required Fields
+
+**Problem:** `WineCharacteristicsData` requires `style: string` and `regionCharacter: string`, but the inline object has `style: string | undefined`.
+
+**Fix:** Provide defaults for required fields.
+
+```typescript
+// client/src/pages/TastingCompletion.tsx:132-141
+
+const characteristics: WineCharacteristicsData | undefined = hasPreUploadedCharacteristics
+  ? {
+      sweetness: expectedCharacteristics.sweetness ?? 3,
+      acidity: expectedCharacteristics.acidity ?? 3,
+      tannins: expectedCharacteristics.tannins ?? 3,
+      body: expectedCharacteristics.body ?? 3,
+      style: expectedCharacteristics.style ?? 'Unknown style',
+      regionCharacter: expectedCharacteristics.regionCharacter ?? 'Unknown region character',
+      source: 'cache' as const
+    }
+  : fetchedCharacteristics?.characteristics;
+```
+
+---
+
+### 6. TastingDetailView.tsx:138 - Missing Interface Property
+
+**Problem:** Code destructures `userParticipant` from `tastingData`, but `TastingDetailData` interface doesn't include it.
+
+**Fix:** Add `userParticipant` to the interface.
+
+```typescript
+// client/src/pages/TastingDetailView.tsx:47-53
+
+interface TastingDetailData {
+  session: TastingSession;
+  wines: WineScore[];
+  sommelierObservations: string[];
+  userNotes: string;
+  overallRating: number;
+  userParticipant?: Participant;  // Add this line
+}
+```
+
+*Note: Need to verify the type of `userParticipant` from the API response.*
+
+---
+
+### 7. server/routes.ts:1096 - Null String
+
+**Problem:** `participantIdToName.get()` returns `string | undefined`, but the code uses `|| 'Participant'` which should handle it. The error says `string | null`.
+
+**Fix:** The Map likely has `null` values. Add null check.
+
+```typescript
+// server/routes.ts:1096
+
+const name = participantIdToName.get(r.participantId) ?? 'Participant';
+// Using ?? instead of || handles both null and undefined
+```
+
+---
+
+## Testing Plan
+
+1. Run `npm run check` after each fix to verify error is resolved
+2. Run `npm run dev` to verify no runtime errors
+3. Manually test affected components:
+   - ModernButton interactions
+   - Video player fullscreen on Safari
+   - Package editor error toasts
+   - Solo tasting detail page
+   - Tasting completion page
+   - Tasting detail view page
+
+---
+
+## References
+
+- `client/src/components/ui/modern-button.tsx:52`
+- `client/src/components/ui/video-player.tsx:257-258`
+- `client/src/pages/PackageEditor.tsx:276`
+- `client/src/pages/SoloTastingDetail.tsx:327`
+- `client/src/pages/TastingCompletion.tsx:132`
+- `client/src/pages/TastingDetailView.tsx:47-53, 138`
+- `server/routes.ts:1096`
+- `shared/schema.ts:667-675` (WineCharacteristicsData interface)

--- a/plans/new-landing-page.md
+++ b/plans/new-landing-page.md
@@ -1,0 +1,257 @@
+	# New Landing Page Design Plan
+
+## Problem Statement
+
+The current gateway at `/` shows 5 equal-weight options (Solo Tasting, Learning Journeys, Join Session, Host Session, Login) which creates decision paralysis. There's no clear value proposition, no trust signals, and it feels like a utility menu rather than a premium wine experience brand introduction.
+
+**Current issues:**
+- No hero section or brand storytelling
+- 5 options with equal visual weight = cognitive overload
+- "Premium Wine Tasting Experience" doesn't explain actual benefits
+- Missing social proof (testimonials, user count, wine collection size)
+- Unclear which features require authentication
+- No visual hierarchy guiding users toward primary action
+
+## Goal
+
+Create a landing page that:
+1. Immediately communicates what Cata is and why users should care
+2. Guides users toward the primary action (start tasting wines)
+3. Feels premium and matches the wine lifestyle brand
+4. Reduces cognitive load with clear visual hierarchy
+5. Works beautifully on mobile (primary target)
+
+---
+
+## Proposed Design
+
+### Visual Structure (Mobile-First)
+
+```
+┌─────────────────────────────────────┐
+│           [Cata Logo]               │
+│                                     │
+│     "Your Personal Sommelier"       │
+│                                     │
+│  Discover wines you'll love through │
+│  guided tastings that learn your    │
+│  unique palate.                     │
+│                                     │
+│  ┌─────────────────────────────┐   │
+│  │    [Start Tasting]          │   │  ← Primary CTA
+│  │    (Gradient button)        │   │
+│  └─────────────────────────────┘   │
+│                                     │
+│     Already have an account?        │
+│     [Sign In]                       │  ← Secondary link
+│                                     │
+├─────────────────────────────────────┤
+│                                     │
+│  ┌───────┐ ┌───────┐ ┌───────┐     │
+│  │ 500+  │ │ 10k+  │ │  AI   │     │  ← Trust metrics
+│  │ Wines │ │Tastings│ │Powered│     │
+│  └───────┘ └───────┘ └───────┘     │
+│                                     │
+├─────────────────────────────────────┤
+│                                     │
+│  How It Works                       │
+│                                     │
+│  1. Taste & Rate                    │
+│     Rate wines on aroma, taste,     │
+│     finish and more                 │
+│                                     │
+│  2. Learn Your Palate               │
+│     AI builds your unique           │
+│     preference profile              │
+│                                     │
+│  3. Discover New Favorites          │
+│     Get personalized wine           │
+│     recommendations                 │
+│                                     │
+├─────────────────────────────────────┤
+│                                     │
+│  [Start Your Wine Journey]          │  ← Bottom CTA
+│                                     │
+├─────────────────────────────────────┤
+│                                     │
+│  For Wine Professionals             │
+│                                     │
+│  [Sommelier Dashboard]              │  ← Build packages (/sommelier)
+│  Create and manage wine tastings    │
+│                                     │
+│  ─────────────────────────────      │
+│                                     │
+│  [Host a Session] [Join Session]    │  ← Run/join sessions
+│                                     │
+└─────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+1. **Single Primary CTA**: "Start Tasting" is the clear action
+   - Goes to `/solo` for personal tasting (creates account if needed)
+   - Removes decision paralysis
+
+2. **Value Proposition First**: Hero explains WHY before showing HOW
+   - "Your Personal Sommelier" - positioning
+   - "Discover wines you'll love..." - benefit statement
+
+3. **Trust Signals**: Show credibility without cluttering
+   - Wine count, tasting count, AI-powered badge
+   - Can be real stats from database
+
+4. **How It Works**: 3-step explanation
+   - Reduces uncertainty for new users
+   - Shows the value journey
+
+5. **Secondary Actions Demoted**: B2B/professional features moved to bottom
+   - These don't compete with consumer entry point
+   - Still accessible for wine professionals
+
+6. **Sign In Link**: Small text link, not a card
+   - Returning users know to look for it
+   - Doesn't compete with new user acquisition
+
+7. **Three Distinct Professional Paths**:
+   - **Sommelier Dashboard** (`/sommelier`) - BUILD packages (create wines, slides, questions)
+   - **Host a Session** (`/host`) - RUN a session using an existing package code
+   - **Join a Session** (`/join`) - For participants joining a live hosted session
+
+---
+
+## Technical Implementation
+
+### Files to Create/Modify
+
+**Create:**
+- `client/src/pages/Landing.tsx` - New landing page component
+
+**Modify:**
+- `client/src/App.tsx` - Update `/` route to use Landing
+- `client/src/components/gateway/SelectionView.tsx` - Can be deprecated or kept for host/join flows
+
+### Component Structure
+
+```tsx
+// Landing.tsx structure
+<div className="min-h-screen bg-gradient-primary">
+  {/* Hero Section */}
+  <section className="pt-16 pb-12 px-4 text-center">
+    <Logo />
+    <Tagline />
+    <ValueProposition />
+    <PrimaryCTA /> {/* "Start Tasting" */}
+    <SignInLink />
+  </section>
+
+  {/* Trust Metrics */}
+  <section className="py-8 px-4">
+    <MetricsRow /> {/* 3 stat cards */}
+  </section>
+
+  {/* How It Works */}
+  <section className="py-12 px-4">
+    <SectionTitle text="How It Works" />
+    <StepCards /> {/* 3 vertical steps */}
+  </section>
+
+  {/* Bottom CTA */}
+  <section className="py-8 px-4 text-center">
+    <SecondaryCTA /> {/* "Start Your Wine Journey" */}
+  </section>
+
+  {/* Host/Group Section */}
+  <section className="py-8 px-4 border-t border-white/10">
+    <SectionTitle text="For Hosts & Groups" />
+    <HostJoinButtons />
+  </section>
+</div>
+```
+
+### Animation Strategy
+
+Using Framer Motion (already in project):
+- Hero elements: Stagger fade-in on load
+- Metrics: Count-up animation when in view
+- Steps: Slide-in from left on scroll
+- CTAs: Subtle pulse/glow effect
+
+```tsx
+// Example animation variants
+const heroVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { staggerChildren: 0.1 }
+  }
+};
+```
+
+### Dynamic Stats
+
+Fetch real stats from backend:
+```tsx
+// New API endpoint needed
+GET /api/stats/public
+Response: {
+  wineCount: 523,
+  tastingCount: 10847,
+  userCount: 1234
+}
+```
+
+Or hardcode reasonable numbers initially and make dynamic later.
+
+---
+
+## Verification
+
+After implementation:
+- [ ] Landing page loads at `/`
+- [ ] "Start Tasting" button goes to `/solo`
+- [ ] "Sign In" link goes to `/login`
+- [ ] "Sommelier Dashboard" goes to `/sommelier` (build packages)
+- [ ] "Host a Session" opens host flow (run a session with package code)
+- [ ] "Join Session" opens join flow (participant joining)
+- [ ] Page looks good on mobile (375px viewport)
+- [ ] Page looks good on desktop (responsive)
+- [ ] Animations are smooth and not distracting
+- [ ] Logo displays correctly
+- [ ] Gradient background matches brand
+
+---
+
+## Future Enhancements (Not in this PR)
+
+- Real-time stats from database
+- Testimonial carousel
+- Featured wine of the week
+- App store badges (if PWA is installable)
+- Video background or wine imagery
+- A/B test different value propositions
+
+---
+
+## Reference: Current SelectionView Options
+
+Mapping current options to new design:
+| Current | New Location | Route |
+|---------|--------------|-------|
+| Solo Tasting | Primary CTA "Start Tasting" | `/solo` |
+| Learning Journeys | Accessible from `/solo` home | `/solo` → Journeys tab |
+| Join Session | Bottom "Join Session" | `/join` modal or route |
+| Host Session | Bottom "Host a Session" | `/host` flow (run with package code) |
+| Login | "Sign In" link below CTA | `/login` |
+| *(New)* Sommelier Dashboard | Bottom "Sommelier Dashboard" | `/sommelier` (build packages) |
+
+---
+
+## Similar Code Reference
+
+- `client/src/pages/SoloLogin.tsx` - Simple centered card layout
+- `client/src/components/gateway/SelectionView.tsx` - Current animation patterns
+- `client/src/pages/HomeV2.tsx` - Glassmorphism card styling
+- `client/src/pages/SommelierDashboard.tsx` - Package management (BUILD tastings)
+- `client/src/pages/HostDashboard.tsx` - Session monitoring (RUN tastings)
+- `client/src/pages/PackageEditor.tsx` - Slide/question builder for packages

--- a/plans/unified-home-v2-three-pillars.md
+++ b/plans/unified-home-v2-three-pillars.md
@@ -1,0 +1,538 @@
+# Unified Home V2: Three Pillars Architecture
+
+## Enhancement Summary
+
+**Deepened on:** 2026-01-21
+**Research agents used:** 7 (TypeScript reviewer, Architecture strategist, Simplicity reviewer, Best practices researcher, Race conditions reviewer, Framework docs researcher, Pattern specialist)
+
+### Key Improvements
+1. **Simplified architecture**: Reduced from 5 new files to 2 (HomeV2.tsx + BottomNav.tsx) with inline tab components
+2. **Race condition mitigations**: Identified 6 potential race conditions with specific fixes
+3. **Type-safe implementation**: Query key factories, discriminated unions for tab state
+4. **Performance optimizations**: Prefetching on tab hover, shared query cache between tabs
+
+### New Considerations Discovered
+- Service Worker caching can cause stale UI - need cache invalidation strategy
+- Tab switching during data fetch needs cleanup via AbortController
+- Reuse existing Gateway components (JoinSessionView, HostSessionView) rather than rebuilding
+- Existing codebase patterns should be followed: glassmorphism cards, AnimatePresence transitions
+
+---
+
+## Problem Statement
+
+The current unified home implementation incorrectly consolidated everything into "solo" experiences, effectively hiding the **Group Tasting** feature which is the ORIGINAL core of the app. The user now sees:
+- Tastings tab (solo only)
+- Journeys tab (solo learning)
+- Profile tab (solo data)
+
+**What's missing**: Group sessions - Join Session, Host Session, group tasting history, group data.
+
+## Product Vision (from CLAUDE.md & PIVOT_RELEASE_NOTES.md)
+
+KnowYourGrape has **THREE** ways to use it:
+
+| Experience | What It Is | Who It's For |
+|------------|-----------|--------------|
+| **Solo Tastings** | Personal wine journal with AI wine recognition | Anyone wanting to track their tastings |
+| **Learning Journeys** | Structured wine education with chapters | Users who want guided learning |
+| **Group Sessions** | Host-led live tastings (original feature) | Events, classes, wine clubs |
+
+**The app should surface ALL THREE experiences, not just solo.**
+
+---
+
+## Proposed Architecture: Three-Tab Home
+
+### Route Structure
+```
+/                          # Gateway (unauthenticated landing)
+/home                      # Unified home (default: Solo tab)
+/home/solo                 # Solo tab (tastings + journeys)
+/home/group                # Group tab (join/host sessions, group history)
+/home/dashboard            # Dashboard tab (all your data, insights, agent chat)
+
+# Action routes (outside tabs)
+/tasting/new               # Start new solo tasting
+/journeys/:id              # Journey detail
+/join                      # Join group session flow
+/host/:sessionId/:id       # Host dashboard
+/tasting/:sessionId/:id    # Group tasting session
+```
+
+### Research Insights: Routing
+
+**Wouter nested routing pattern:**
+```typescript
+// In App.tsx - use nest prop for /home/* routes
+<Route path="/home" nest>
+  <Route path="/" component={HomeV2} />
+  <Route path="/solo" component={HomeV2} />
+  <Route path="/group" component={HomeV2} />
+  <Route path="/dashboard" component={HomeV2} />
+</Route>
+
+// In HomeV2.tsx - useRoute to detect active tab
+const [isSolo] = useRoute("/home/solo");
+const [isGroup] = useRoute("/home/group");
+const [isDashboard] = useRoute("/home/dashboard");
+```
+
+**Performance: Prefetch on hover:**
+```typescript
+const queryClient = useQueryClient();
+
+const handleTabHover = (tab: TabType) => {
+  if (tab === 'group') {
+    queryClient.prefetchQuery({
+      queryKey: ['group-sessions', user?.email],
+      queryFn: fetchGroupSessions,
+      staleTime: 30000,
+    });
+  }
+};
+```
+
+### Bottom Tab Bar
+```
++------------------+------------------+------------------+
+|       Solo       |      Group       |    Dashboard     |
+|  (Wine glass)    |    (Users)       |   (BarChart)     |
++------------------+------------------+------------------+
+```
+
+### Research Insights: Tab Navigation
+
+**Mobile-first best practices:**
+- Touch targets: minimum 44x44px (Apple HIG), 48x48dp (Material)
+- Active state: filled icon + label, inactive: outline icon only
+- Safe area: respect `env(safe-area-inset-bottom)` for notched devices
+- Haptic feedback on tab change via `useHaptics` hook
+
+**Configuration-driven navigation:**
+```typescript
+const TAB_CONFIG = [
+  { key: 'solo', path: '/home/solo', icon: Wine, label: 'Solo' },
+  { key: 'group', path: '/home/group', icon: Users, label: 'Group' },
+  { key: 'dashboard', path: '/home/dashboard', icon: BarChart3, label: 'Dashboard' },
+] as const;
+
+type TabKey = typeof TAB_CONFIG[number]['key'];
+```
+
+---
+
+## Tab Content Design
+
+### Solo Tab (`/home` or `/home/solo`)
+
+**Purpose**: Your personal wine journey - tastings you've done alone and learning paths.
+
+**Content**:
+1. **Hero Action Card**
+   - "Start New Tasting" button (prominent)
+   - Quick stats: X solo tastings, current streak
+
+2. **Continue Journey** (if in progress)
+   - Current chapter, progress bar
+   - "Continue" button
+
+3. **Recent Solo Tastings**
+   - List of recent wines tasted solo
+   - Tap to view detail
+
+4. **Browse Journeys**
+   - Journey cards grid
+   - Filter by difficulty/type
+
+**Actions**:
+- Start New Tasting → `/tasting/new`
+- View Tasting → `/solo/tasting/:id`
+- Continue Journey → `/journeys/:id`
+- Browse Journeys → expandable section or modal
+
+### Research Insights: Solo Tab
+
+**Reuse existing components from HomeTastings.tsx:**
+- TastingCard component for recent tastings list
+- Journey continuation card logic
+- Empty state messaging
+
+**Animation pattern (from codebase):**
+```typescript
+<AnimatePresence mode="wait">
+  {activeJourney && (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -10 }}
+    >
+      {/* Continue Journey card */}
+    </motion.div>
+  )}
+</AnimatePresence>
+```
+
+---
+
+### Group Tab (`/home/group`)
+
+**Purpose**: Live sessions with others - join, host, and review your group experiences.
+
+**Content**:
+1. **Quick Actions** (two prominent buttons)
+   - "Join Session" - Enter with code or scan QR
+   - "Host Session" - Start with package code
+
+2. **Active Session** (if any)
+   - Session you're currently in
+   - "Rejoin" button
+
+3. **Recent Group Tastings**
+   - Sessions you've participated in
+   - Shows: Package name, date, host, wines tasted
+   - Badge: "Hosted" vs "Participated"
+
+4. **Group Stats**
+   - Total group tastings
+   - Unique hosts/groups
+   - Favorite package/wine from group sessions
+
+**Actions**:
+- Join Session → `/join` modal or page
+- Host Session → `/host` flow
+- View Group Tasting → `/dashboard/:email/tasting/:sessionId`
+
+### Research Insights: Group Tab
+
+**Critical: Reuse Gateway components directly:**
+```typescript
+import { JoinSessionView } from "@/components/gateway/JoinSessionView";
+import { HostSessionView } from "@/components/gateway/HostSessionView";
+
+// These components already handle:
+// - Session code input with validation
+// - QR scanner modal
+// - Package code input
+// - Host display name
+// - Error states and loading
+```
+
+**Session restoration (from Gateway.tsx):**
+```typescript
+const { activeSession, endSession } = useSessionPersistence();
+
+// Check for active session on mount
+useEffect(() => {
+  if (activeSession && activeSession.isActive) {
+    setShowRestoreModal(true);
+  }
+}, [activeSession]);
+```
+
+**Race condition mitigation - tab switch during session validation:**
+```typescript
+const abortControllerRef = useRef<AbortController | null>(null);
+
+const validateSession = async (sessionCode: string) => {
+  abortControllerRef.current?.abort();
+  abortControllerRef.current = new AbortController();
+
+  try {
+    const response = await fetch(`/api/sessions/${sessionCode}`, {
+      signal: abortControllerRef.current.signal,
+    });
+    // ...
+  } catch (e) {
+    if (e.name !== 'AbortError') throw e;
+  }
+};
+
+// Cleanup on unmount or tab change
+useEffect(() => {
+  return () => abortControllerRef.current?.abort();
+}, []);
+```
+
+---
+
+### Dashboard Tab (`/home/dashboard`)
+
+**Purpose**: ALL your wine data in one place - unified view of solo + group tastings, insights, and eventually AI agent chat.
+
+**Content**:
+1. **Overview Stats**
+   - Total tastings (X solo + Y group = Z total)
+   - Unique wines
+   - Average rating
+   - Favorite region/grape
+
+2. **Taste Profile** (from existing UserDashboard)
+   - Preference bars (sweetness, acidity, tannins, body)
+   - One-line summary
+   - Red Wine Profile card
+   - White Wine Profile card
+
+3. **Wine Collection**
+   - ALL wines rated (solo + group combined)
+   - Filter: All | Solo | Group
+   - Sort: Recent, Rating, Region
+
+4. **Sommelier Tips** (if enough data)
+   - What to ask at restaurants
+   - Wines to explore next
+
+5. **Future: Chat with Your Data**
+   - "Ask about your wines" input
+   - Photo menu scanner
+   - AI recommendations
+
+**Data Sources**:
+- `/api/dashboard/:email` - existing endpoint
+- `/api/solo/preferences` - solo preferences
+- Combine both data sources
+
+### Research Insights: Dashboard Tab
+
+**Query key factory pattern:**
+```typescript
+const dashboardKeys = {
+  all: ['dashboard'] as const,
+  user: (email: string) => [...dashboardKeys.all, email] as const,
+  solo: (email: string) => [...dashboardKeys.user(email), 'solo'] as const,
+  group: (email: string) => [...dashboardKeys.user(email), 'group'] as const,
+  unified: (email: string) => [...dashboardKeys.user(email), 'unified'] as const,
+};
+```
+
+**Parallel queries for combined data:**
+```typescript
+const { data: dashboardData } = useQuery({
+  queryKey: dashboardKeys.user(user.email),
+  queryFn: () => apiRequest('GET', `/api/dashboard/${user.email}`),
+});
+
+const { data: soloData } = useQuery({
+  queryKey: dashboardKeys.solo(user.email),
+  queryFn: () => apiRequest('GET', '/api/solo/preferences'),
+});
+
+// Combine in component
+const totalTastings = (dashboardData?.totalTastings ?? 0) + (soloData?.tastingCount ?? 0);
+```
+
+**Reuse existing UserDashboard components:**
+- TasteProfileCard
+- WinePreferenceBars
+- SommelierTips section
+- Wine collection grid
+
+---
+
+## Implementation Phases (Simplified)
+
+### Research Insight: Reduce to 2 Phases
+
+The simplicity reviewer recommended consolidating 5 phases to 2, and reducing 5 new files to 2:
+
+### Phase 1: Build HomeV2 with All Three Tabs
+
+**Single file approach (HomeV2.tsx):**
+```typescript
+// HomeV2.tsx - ~300 lines with inline tab components
+export default function HomeV2() {
+  const [location, setLocation] = useLocation();
+  const activeTab = location.includes('/group') ? 'group'
+                  : location.includes('/dashboard') ? 'dashboard'
+                  : 'solo';
+
+  return (
+    <div className="min-h-screen bg-gradient-primary pb-20">
+      <AnimatePresence mode="wait">
+        {activeTab === 'solo' && <SoloTabContent key="solo" />}
+        {activeTab === 'group' && <GroupTabContent key="group" />}
+        {activeTab === 'dashboard' && <DashboardTabContent key="dashboard" />}
+      </AnimatePresence>
+
+      <BottomNav activeTab={activeTab} />
+    </div>
+  );
+}
+
+// Inline tab components (or extract to separate files if >100 lines each)
+function SoloTabContent() { /* ... */ }
+function GroupTabContent() { /* ... */ }
+function DashboardTabContent() { /* ... */ }
+```
+
+**Tasks:**
+- [ ] Create `HomeV2.tsx` with tab switching logic
+- [ ] Create `BottomNav.tsx` component (reuse existing BottomTabBar patterns)
+- [ ] Implement SoloTabContent (reuse HomeTastings content)
+- [ ] Implement GroupTabContent (reuse Gateway JoinSessionView/HostSessionView)
+- [ ] Implement DashboardTabContent (reuse UserDashboard content)
+- [ ] Add routes in App.tsx
+
+### Phase 2: Cleanup & Polish
+
+**Tasks:**
+- [ ] Update Gateway to show options for unauthenticated only
+- [ ] Add redirects from old routes (`/solo` → `/home`, etc.)
+- [ ] Test all flows end-to-end
+- [ ] Remove deprecated files after verification
+- [ ] Clear Service Worker cache on deploy
+
+---
+
+## Files to Create/Modify
+
+**New files (reduced from 5 to 2):**
+- `client/src/pages/HomeV2.tsx` - Unified home with inline tab components (~300 lines)
+- `client/src/components/home/BottomNav.tsx` - Three-tab navigation (~80 lines)
+
+**Modify:**
+- `client/src/App.tsx` - Add new routes with `nest` prop
+- `client/src/pages/Gateway.tsx` - Keep for unauthenticated only (no changes needed)
+
+**Eventually delete:**
+- `client/src/pages/Home.tsx` (old version)
+- `client/src/pages/HomeTastings.tsx`
+- `client/src/pages/HomeJourneys.tsx`
+- `client/src/pages/HomeProfile.tsx`
+- `client/src/components/layout/HomeLayout.tsx`
+- `client/src/components/layout/BottomTabBar.tsx`
+
+---
+
+## Race Condition Mitigations
+
+The race conditions reviewer identified 6 potential issues:
+
+### 1. Tab switching during data fetch
+**Risk:** User switches tabs before query completes, stale data renders
+**Fix:** Use AbortController, check `isMounted` ref before setState
+
+### 2. Auth state changes during navigation
+**Risk:** User logs out mid-navigation, crash or wrong state
+**Fix:** Guard all navigation with `if (!user) return;`
+
+### 3. Service Worker cache serving stale UI
+**Risk:** After deploy, users see old UI until hard refresh
+**Fix:** Version SW cache, use `skipWaiting()` + notify user to refresh
+
+### 4. Optimistic updates with network failures
+**Risk:** UI shows success but network fails
+**Fix:** TanStack Query's `onError` rollback, show toast on failure
+
+### 5. Session restoration conflicts
+**Risk:** User has active session but starts new one
+**Fix:** SessionRestoreModal (already in Gateway.tsx), check before allowing new session
+
+### 6. Animation state during rapid tab switches
+**Risk:** AnimatePresence gets confused with rapid switching
+**Fix:** Use `mode="wait"` and unique keys per tab
+
+---
+
+## Codebase Patterns to Follow
+
+### Card Styling (glassmorphism pattern)
+```typescript
+className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-2xl p-5 border border-white/20"
+```
+
+### Animation Pattern
+```typescript
+<motion.div
+  initial={{ opacity: 0, y: 20 }}
+  animate={{ opacity: 1, y: 0 }}
+  transition={{ duration: 0.3 }}
+>
+```
+
+### Data Fetching Pattern
+```typescript
+const { data, isLoading, error } = useQuery({
+  queryKey: ['/api/endpoint', param],
+  queryFn: async () => {
+    const response = await apiRequest('GET', `/api/endpoint/${param}`, null);
+    if (!response.ok) throw new Error('Failed to fetch');
+    return response.json();
+  },
+  enabled: !!param,
+});
+```
+
+### Loading State
+```typescript
+if (isLoading) {
+  return (
+    <div className="min-h-screen bg-gradient-primary flex items-center justify-center">
+      <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
+    </div>
+  );
+}
+```
+
+### Empty State
+```typescript
+<div className="text-center py-12">
+  <Wine className="w-12 h-12 text-white/30 mx-auto mb-4" />
+  <p className="text-white/60">No tastings yet</p>
+  <Button onClick={() => setLocation('/tasting/new')}>
+    Start Your First Tasting
+  </Button>
+</div>
+```
+
+---
+
+## Key Principles
+
+1. **Three Pillars, Not One**: Solo, Group, and Dashboard are equal citizens
+2. **Group Sessions are NOT deprecated**: They're the original value prop
+3. **Dashboard unifies ALL data**: Solo + Group in one view
+4. **Clear mental model**:
+   - Solo = my personal wine journey
+   - Group = social tasting experiences
+   - Dashboard = everything about my wine data
+
+---
+
+## Success Criteria
+
+- [ ] User can start a solo tasting from Solo tab
+- [ ] User can join/host group session from Group tab
+- [ ] User can see ALL their tastings (solo + group) in Dashboard
+- [ ] Group tasting history is visible and accessible
+- [ ] Existing features (journeys, profile, wine intelligence) all still work
+- [ ] Navigation is clear and thumb-friendly on mobile
+- [ ] No features are hidden or removed
+- [ ] Tab switching is smooth with proper animations
+- [ ] No race conditions on rapid tab switching
+
+---
+
+## What This Plan Does NOT Change
+
+- Group session flow (`/join`, `/tasting/:id/:id`, `/host/:id/:id`)
+- Solo tasting flow (`/tasting/new`, `/solo/tasting/:id`)
+- Journey flow (`/journeys/:id`)
+- Sommelier Dashboard (`/sommelier`)
+- Package Editor (`/editor/:code`)
+- Journey Admin (`/admin/journeys`)
+- API endpoints
+
+---
+
+## Reference Files
+
+- `CLAUDE.md` - Architecture overview
+- `PRODUCT_ROADMAP.md` - Vision and priorities
+- `PIVOT_RELEASE_NOTES.md` - Three experiences table
+- `FEATURE_BACKLOG.md` - Dashboard redesign spec
+- `client/src/pages/UserDashboard.tsx` - Existing dashboard with taste profile
+- `client/src/pages/Gateway.tsx` - Join/Host session views
+- `client/src/components/gateway/SelectionView.tsx` - Gateway options
+- `client/src/components/gateway/JoinSessionView.tsx` - Join session UI (REUSE)
+- `client/src/components/gateway/HostSessionView.tsx` - Host session UI (REUSE)

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,7 @@ app.use(express.urlencoded({ extended: false, limit: '10mb' }));
 
 // Session configuration for solo tasting auth
 app.use(session({
-  secret: process.env.SESSION_SECRET || 'kyg-solo-tasting-secret-change-in-production',
+  secret: process.env.SESSION_SECRET || 'cata-tasting-secret-change-in-production',
   resave: false,
   saveUninitialized: false,
   cookie: {
@@ -28,7 +28,7 @@ app.use(session({
     maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
     sameSite: process.env.NODE_ENV === 'production' ? 'strict' : 'lax'
   },
-  name: 'kyg.sid' // Custom session cookie name
+  name: 'cata.sid' // Custom session cookie name
 }));
 
 // Check database migration status on startup
@@ -89,7 +89,7 @@ app.use(session({
 // Configure CORS
 app.use(cors({
   origin: process.env.NODE_ENV === 'production' 
-    ? ['https://knowyourgrape.com', 'https://www.knowyourgrape.com'] // Update with your production domain
+    ? ['https://cata.wine', 'https://www.cata.wine', 'https://cata-production.up.railway.app'] // Production domains
     : true, // Allow all origins in development
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -188,7 +188,7 @@ export function registerAuthRoutes(app: Express): void {
         console.error("Logout error:", err);
         return res.status(500).json({ error: "Logout failed" });
       }
-      res.clearCookie("kyg.sid");
+      res.clearCookie("cata.sid");
       return res.json({ success: true });
     });
   });


### PR DESCRIPTION
## Summary
- New landing page at `/` with clear consumer-focused CTA hierarchy
- Replaces the 5-option menu that caused decision paralysis
- Single primary action: "Start Tasting" → `/home`
- Professional features (Sommelier Dashboard, Host/Join) demoted to bottom section
- Added logout dropdown menu to authenticated home pages
- Updated Cata logo SVGs

## Changes
| Feature | Description |
|---------|-------------|
| **New Landing Page** | Hero section with value proposition, trust metrics, "How It Works" steps |
| **Clear CTA Hierarchy** | Primary: "Start Tasting", Secondary: "Sign In", Professional section at bottom |
| **Logout Feature** | User menu dropdown with sign out in HomeV2 and HomeTastings headers |
| **Logo Updates** | Improved Cata branding SVGs |

## Routes
- `/` → New Landing page (consumer-focused)
- `/gateway` → Old Gateway (preserved for reference)
- `/sommelier` → Sommelier Dashboard (build packages)
- `/join` → Join/Host session flow

## Testing
- [x] TypeScript compiles (`npm run check`)
- [ ] Manual test: Landing page loads at `/`
- [ ] Manual test: "Start Tasting" goes to `/home`
- [ ] Manual test: "Sign In" goes to `/login`
- [ ] Manual test: "Sommelier Dashboard" goes to `/sommelier`
- [ ] Manual test: Logout works from home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)