### PR TITLE
feat: hybrid onboarding flow (quiz + Pierre handoff)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,6 +33,7 @@ const SessionJoin = lazy(() => import("@/pages/SessionJoin"));
 const TastingSession = lazy(() => import("@/pages/TastingSession"));
 const TastingCompletion = lazy(() => import("@/pages/TastingCompletion"));
 const HostDashboard = lazy(() => import("@/pages/HostDashboard"));
+const OnboardingQuiz = lazy(() => import("@/pages/OnboardingQuiz"));
 
 import { SommelierFAB } from "@/components/sommelier/SommelierFAB";
 
@@ -40,6 +41,7 @@ function Router() {
   return (
     <Switch>
       <Route path="/" component={Landing} />
+      <Route path="/onboarding" component={OnboardingQuiz} />
       <Route path="/gateway" component={Gateway} /> {/* Keep old gateway accessible */}
 
       {/* New unified home experience - Three Pillars (Solo, Group, Dashboard) */}

--- a/client/src/components/sommelier/ChatMessage.tsx
+++ b/client/src/components/sommelier/ChatMessage.tsx
@@ -1,16 +1,19 @@
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { useLocation } from "wouter";
 import type { ChatMessage as ChatMessageType } from "@/hooks/useSommelierChat";
 import { Camera, RotateCcw } from "lucide-react";
 
 interface ChatMessageProps {
   message: ChatMessageType;
   onRetry?: (messageId: number) => void;
+  onNavigate?: () => void;
 }
 
-export function ChatMessage({ message, onRetry }: ChatMessageProps) {
+export function ChatMessage({ message, onRetry, onNavigate }: ChatMessageProps) {
   const isUser = message.role === "user";
   const hasImage = (message.metadata as any)?.hasImage;
+  const [, setLocation] = useLocation();
 
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"} px-4 py-1`}>
@@ -33,7 +36,31 @@ export function ChatMessage({ message, onRetry }: ChatMessageProps) {
           <p className="text-sm whitespace-pre-wrap">{message.content}</p>
         ) : (
           <div className="text-sm prose prose-invert prose-sm max-w-none prose-p:my-1 prose-ul:my-1 prose-li:my-0.5 prose-headings:my-2 prose-strong:text-white">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                a: ({ href, children }) => {
+                  if (href?.startsWith("/")) {
+                    return (
+                      <button
+                        onClick={() => {
+                          onNavigate?.();
+                          setLocation(href);
+                        }}
+                        className="text-purple-400 underline hover:text-purple-300 cursor-pointer inline"
+                      >
+                        {children}
+                      </button>
+                    );
+                  }
+                  return (
+                    <a href={href} target="_blank" rel="noopener noreferrer">
+                      {children}
+                    </a>
+                  );
+                },
+              }}
+            >
               {message.content}
             </ReactMarkdown>
           </div>

--- a/client/src/components/sommelier/MessageList.tsx
+++ b/client/src/components/sommelier/MessageList.tsx
@@ -7,9 +7,10 @@ interface MessageListProps {
   messages: ChatMessageType[];
   isStreaming: boolean;
   onRetryMessage?: (messageId: number) => void;
+  onNavigate?: () => void;
 }
 
-export function MessageList({ messages, isStreaming, onRetryMessage }: MessageListProps) {
+export function MessageList({ messages, isStreaming, onRetryMessage, onNavigate }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
@@ -37,7 +38,7 @@ export function MessageList({ messages, isStreaming, onRetryMessage }: MessageLi
       onScroll={handleScroll}
     >
       {messages.map((message) => (
-        <ChatMessage key={message.id} message={message} onRetry={onRetryMessage} />
+        <ChatMessage key={message.id} message={message} onRetry={onRetryMessage} onNavigate={onNavigate} />
       ))}
       {isStreaming && !messages[messages.length - 1]?.isStreaming && (
         <TypingIndicator />

--- a/client/src/components/sommelier/SommelierChatSheet.tsx
+++ b/client/src/components/sommelier/SommelierChatSheet.tsx
@@ -84,6 +84,7 @@ Or just ask me anything — what sounds good?`;
 interface SommelierChatSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  isWelcome?: boolean;
 }
 
 function WelcomeState({
@@ -276,7 +277,7 @@ function ChatContent({
   );
 }
 
-export function SommelierChatSheet({ open, onOpenChange }: SommelierChatSheetProps) {
+export function SommelierChatSheet({ open, onOpenChange, isWelcome }: SommelierChatSheetProps) {
   const isMobile = useIsMobile();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const {
@@ -306,13 +307,13 @@ export function SommelierChatSheet({ open, onOpenChange }: SommelierChatSheetPro
     staleTime: 5 * 60 * 1000,
   });
 
-  // Persist personalized welcome message when opened via ?pierre=welcome
+  // Persist personalized welcome message when opened via isWelcome prop
   const welcomeInjected = useRef(false);
   useEffect(() => {
     if (
       open &&
+      isWelcome &&
       !welcomeInjected.current &&
-      window.location.search.includes("pierre=welcome") &&
       messages.length === 0
     ) {
       welcomeInjected.current = true;
@@ -344,13 +345,8 @@ export function SommelierChatSheet({ open, onOpenChange }: SommelierChatSheetPro
             createdAt: new Date().toISOString(),
           });
         });
-
-      // Clean up URL param
-      const url = new URL(window.location.href);
-      url.searchParams.delete("pierre");
-      window.history.replaceState({}, "", url.pathname + url.search);
     }
-  }, [open, messages.length, authData, setWelcomeState]);
+  }, [open, isWelcome, messages.length, authData, setWelcomeState]);
 
   const handleClose = () => onOpenChange(false);
   const openSidebar = useCallback(() => setSidebarOpen(true), []);

--- a/client/src/components/sommelier/SommelierChatSheet.tsx
+++ b/client/src/components/sommelier/SommelierChatSheet.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from "react";
+import { useRef, useState, useCallback, useEffect } from "react";
 import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import { ChatHeader } from "./ChatHeader";
 import { ChatHistorySidebar } from "./ChatHistorySidebar";
@@ -6,13 +6,80 @@ import { MessageList } from "./MessageList";
 import { ChatInput } from "./ChatInput";
 import { useSommelierChat } from "@/hooks/useSommelierChat";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useQuery } from "@tanstack/react-query";
 import { Camera, Sparkles, Wine } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
+import type { OnboardingData } from "@shared/schema";
 
 const SUGGESTED_PROMPTS = [
   { icon: Sparkles, text: "What's a wine I'd love but haven't tried yet?" },
   { icon: Wine, text: "I'm cooking tonight \u2014 what should I open?" },
 ];
+
+function buildWelcomeMessage(data?: OnboardingData | null): string {
+  const allNotSure =
+    !data ||
+    (data.knowledgeLevel === "not_sure" &&
+      data.wineVibe === "not_sure" &&
+      (!data.foodPreferences || data.foodPreferences.length === 0) &&
+      (!data.drinkPreferences || data.drinkPreferences.length === 0) &&
+      data.occasion === "not_sure");
+
+  // --- Personalized opening ---
+  let opening: string;
+  if (allNotSure) {
+    opening =
+      "Hey! I'm Pierre, your personal wine guide. Not sure what you like yet? That's literally what Cata is for.";
+  } else {
+    const vibeOpeners: Record<string, string> = {
+      bold: "You like bold, full-bodied wines?",
+      light: "You appreciate lighter, crisp wines?",
+      sweet: "You're drawn to sweeter wines?",
+      adventurous: "Love that you're adventurous with wine —",
+    };
+    const vibe = data?.wineVibe && data.wineVibe !== "not_sure"
+      ? vibeOpeners[data.wineVibe] || ""
+      : "";
+    opening = vibe
+      ? `Hey! I'm Pierre, your personal wine guide. ${vibe} We're going to get along.`
+      : "Hey! I'm Pierre, your personal wine guide. Let's figure out what you love.";
+  }
+
+  // --- Feature links (always the same) ---
+  const features = [
+    "**[Taste a wine](/tasting/new)** — snap any bottle, answer a few fun questions, and our system starts learning what you love (and what you don't)",
+    "**[Learning Journeys](/journeys)** — guided tastings with sommelier-designed questions that build your palate step by step",
+    "**[Group tastings](/home/group)** — host a tasting night with friends, pick a curated wine set, and compare notes live",
+    "**[Your taste profile](/home/dashboard)** — watch your palate evolve as you taste more",
+  ];
+
+  // --- Recommendation based on occasion ---
+  const occasionRecommendations: Record<string, string> = {
+    learning:
+      "Since you're here to learn, I'd start by **[tasting whatever you're drinking right now](/tasting/new)** — even if it's just Tuesday night wine. That's how I start learning what clicks for you.",
+    go_to_bottle:
+      "Since you want to find a go-to bottle, I'd start by **[tasting whatever you're drinking right now](/tasting/new)** — that's how we zero in on your perfect everyday pick.",
+    impress:
+      "Want to level up your wine game? Start by **[tasting a wine you already like](/tasting/new)** — I'll teach you why you like it, so you can talk about it confidently.",
+    date_night:
+      "Looking for that perfect bottle? **[Taste what you know first](/tasting/new)** — I'll use that to find special-occasion wines you'll both love.",
+  };
+
+  const recommendation =
+    data?.occasion && data.occasion !== "not_sure"
+      ? occasionRecommendations[data.occasion]
+      : "The best place to start? **[Taste whatever you're drinking right now](/tasting/new)** — even if it's just Tuesday night wine. That's how I start learning your palate.";
+
+  return `${opening}
+
+Cata isn't a wine textbook — it's about discovering what **you** like. Here's how:
+
+- ${features.join("\n- ")}
+
+${recommendation}
+
+Or just ask me anything — what sounds good?`;
+}
 
 interface SommelierChatSheetProps {
   open: boolean;
@@ -136,6 +203,7 @@ function ChatContent({
   onNewChat,
   onDeleteChat,
   onRetryMessage,
+  onNavigate,
 }: {
   onClose: () => void;
   messages: any[];
@@ -156,6 +224,7 @@ function ChatContent({
   onNewChat: () => void;
   onDeleteChat: (chatId: number) => void;
   onRetryMessage?: (messageId: number) => void;
+  onNavigate?: () => void;
 }) {
   const showWelcome = !isLoading && !isLoadingChat && messages.length === 0;
   const swipeHandlers = useEdgeSwipe(onOpenSidebar);
@@ -183,7 +252,7 @@ function ChatContent({
       ) : showWelcome ? (
         <WelcomeState onSelectPrompt={sendMessage} onSendWithImage={sendMessageWithImage} />
       ) : (
-        <MessageList messages={messages} isStreaming={isStreaming} onRetryMessage={onRetryMessage} />
+        <MessageList messages={messages} isStreaming={isStreaming} onRetryMessage={onRetryMessage} onNavigate={onNavigate} />
       )}
 
       <ChatInput
@@ -225,8 +294,37 @@ export function SommelierChatSheet({ open, onOpenChange }: SommelierChatSheetPro
     deleteChat,
     startNewChat,
     retryMessage,
+    injectMessage,
     clearError,
   } = useSommelierChat(open);
+
+  // Get onboarding data for welcome message personalization
+  const { data: authData } = useQuery<{
+    user: { onboardingCompleted: boolean; onboardingData?: OnboardingData };
+  }>({
+    queryKey: ["/api/auth/me"],
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Inject personalized welcome message when opened via ?pierre=welcome
+  const welcomeInjected = useRef(false);
+  useEffect(() => {
+    if (
+      open &&
+      !welcomeInjected.current &&
+      window.location.search.includes("pierre=welcome") &&
+      messages.length === 0
+    ) {
+      welcomeInjected.current = true;
+      const onboardingData = authData?.user?.onboardingData;
+      injectMessage(buildWelcomeMessage(onboardingData));
+
+      // Clean up URL param
+      const url = new URL(window.location.href);
+      url.searchParams.delete("pierre");
+      window.history.replaceState({}, "", url.pathname + url.search);
+    }
+  }, [open, messages.length, authData, injectMessage]);
 
   const handleClose = () => onOpenChange(false);
   const openSidebar = useCallback(() => setSidebarOpen(true), []);
@@ -258,6 +356,7 @@ export function SommelierChatSheet({ open, onOpenChange }: SommelierChatSheetPro
     },
     onDeleteChat: deleteChat,
     onRetryMessage: retryMessage,
+    onNavigate: handleClose,
   };
 
   // Mobile: bottom drawer (handleOnly prevents scroll-triggered dismiss)

--- a/client/src/components/sommelier/SommelierFAB.tsx
+++ b/client/src/components/sommelier/SommelierFAB.tsx
@@ -59,8 +59,9 @@ export function SommelierFAB() {
   const { triggerHaptic } = useHaptics();
 
   // Auto-open Pierre after onboarding completion
+  // Note: wouter's useLocation returns only pathname, not search params
   useEffect(() => {
-    if (location.includes("pierre=welcome")) {
+    if (window.location.search.includes("pierre=welcome")) {
       const timer = setTimeout(() => setIsOpen(true), 600);
       return () => clearTimeout(timer);
     }

--- a/client/src/components/sommelier/SommelierFAB.tsx
+++ b/client/src/components/sommelier/SommelierFAB.tsx
@@ -55,13 +55,19 @@ function PierreIcon({ className }: { className?: string }) {
 
 export function SommelierFAB() {
   const [isOpen, setIsOpen] = useState(false);
+  const [isWelcome, setIsWelcome] = useState(false);
   const [location] = useLocation();
   const { triggerHaptic } = useHaptics();
 
   // Auto-open Pierre after onboarding completion
-  // Note: wouter's useLocation returns only pathname, not search params
   useEffect(() => {
     if (window.location.search.includes("pierre=welcome")) {
+      setIsWelcome(true);
+      // Clean URL param immediately
+      const url = new URL(window.location.href);
+      url.searchParams.delete("pierre");
+      window.history.replaceState({}, "", url.pathname + url.search);
+
       const timer = setTimeout(() => setIsOpen(true), 600);
       return () => clearTimeout(timer);
     }
@@ -117,7 +123,7 @@ export function SommelierFAB() {
       </AnimatePresence>
 
       {showChatSheet && (
-        <SommelierChatSheet open={isOpen} onOpenChange={setIsOpen} />
+        <SommelierChatSheet open={isOpen} onOpenChange={setIsOpen} isWelcome={isWelcome} />
       )}
     </>
   );

--- a/client/src/components/sommelier/SommelierFAB.tsx
+++ b/client/src/components/sommelier/SommelierFAB.tsx
@@ -79,13 +79,14 @@ export function SommelierFAB() {
   const isHidden = HIDDEN_ROUTE_PATTERNS.some((p) => p.test(location));
   const isShown = SHOWN_ROUTE_PATTERNS.some((p) => p.test(location));
 
-  // Check sessionStorage for pierre_welcome flag (survives redirects unlike URL params)
+  // Check sessionStorage for pierre_welcome flag (survives redirects unlike URL params).
+  // Opens Pierre immediately — no setTimeout because any dependency change would
+  // cancel the timeout after the flag is already consumed, with no way to retry.
   useEffect(() => {
     if (sessionStorage.getItem("pierre_welcome") && isAuthenticated && isShown && !isHidden) {
       sessionStorage.removeItem("pierre_welcome");
       setIsWelcome(true);
-      const timer = setTimeout(() => setIsOpen(true), 600);
-      return () => clearTimeout(timer);
+      setIsOpen(true);
     }
   }, [location, isAuthenticated, isShown, isHidden]);
 

--- a/client/src/components/sommelier/SommelierFAB.tsx
+++ b/client/src/components/sommelier/SommelierFAB.tsx
@@ -79,25 +79,15 @@ export function SommelierFAB() {
   const isHidden = HIDDEN_ROUTE_PATTERNS.some((p) => p.test(location));
   const isShown = SHOWN_ROUTE_PATTERNS.some((p) => p.test(location));
 
-  // Detect ?pierre=welcome URL param (set once, persists across route changes)
+  // Check sessionStorage for pierre_welcome flag (survives redirects unlike URL params)
   useEffect(() => {
-    if (window.location.search.includes("pierre=welcome")) {
+    if (sessionStorage.getItem("pierre_welcome") && isAuthenticated && isShown && !isHidden) {
+      sessionStorage.removeItem("pierre_welcome");
       setIsWelcome(true);
-      // Clean URL param immediately
-      const url = new URL(window.location.href);
-      url.searchParams.delete("pierre");
-      window.history.replaceState({}, "", url.pathname + url.search);
-    }
-  }, [location]);
-
-  // Auto-open Pierre once isWelcome is set and we're on a visible route.
-  // Separate from URL detection so redirect ping-pong doesn't cancel the timeout.
-  useEffect(() => {
-    if (isWelcome && !isOpen && isAuthenticated && isShown && !isHidden) {
       const timer = setTimeout(() => setIsOpen(true), 600);
       return () => clearTimeout(timer);
     }
-  }, [isWelcome, isOpen, isAuthenticated, isShown, isHidden]);
+  }, [location, isAuthenticated, isShown, isHidden]);
 
   // FAB button only shows on allowed routes when not chatting
   const showFABButton = isAuthenticated && !isHidden && isShown && !isOpen;

--- a/client/src/components/sommelier/SommelierFAB.tsx
+++ b/client/src/components/sommelier/SommelierFAB.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useLocation } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import { motion, AnimatePresence } from "framer-motion";
@@ -7,6 +7,7 @@ import { useHaptics } from "@/hooks/useHaptics";
 
 // Routes where the FAB should be hidden (active experiences)
 const HIDDEN_ROUTE_PATTERNS = [
+  /^\/onboarding$/,
   /^\/tasting\/[^/]+\/[^/]+$/, // /tasting/:sessionId/:participantId
   /^\/tasting\/new$/,
   /^\/solo\/new$/,
@@ -56,6 +57,14 @@ export function SommelierFAB() {
   const [isOpen, setIsOpen] = useState(false);
   const [location] = useLocation();
   const { triggerHaptic } = useHaptics();
+
+  // Auto-open Pierre after onboarding completion
+  useEffect(() => {
+    if (location.includes("pierre=welcome")) {
+      const timer = setTimeout(() => setIsOpen(true), 600);
+      return () => clearTimeout(timer);
+    }
+  }, [location]);
 
   // Use the same auth query as HomeV2 so they share cache state.
   // retry:1 + placeholderData prevents chat death on tab-switch refetch failures.

--- a/client/src/hooks/useSommelierChat.ts
+++ b/client/src/hooks/useSommelierChat.ts
@@ -313,6 +313,16 @@ export function useSommelierChat(isOpen: boolean) {
     setIsStreaming(false);
   }, []);
 
+  // Inject a synthetic assistant message (for welcome message)
+  const injectMessage = useCallback((content: string) => {
+    setMessages([{
+      id: -2,
+      role: "assistant",
+      content,
+      createdAt: new Date().toISOString(),
+    }]);
+  }, []);
+
   const clearError = useCallback(() => setError(null), []);
 
   return {
@@ -331,6 +341,7 @@ export function useSommelierChat(isOpen: boolean) {
     startNewChat,
     cancelStream,
     retryMessage,
+    injectMessage,
     clearError,
   };
 }

--- a/client/src/hooks/useSommelierChat.ts
+++ b/client/src/hooks/useSommelierChat.ts
@@ -313,15 +313,12 @@ export function useSommelierChat(isOpen: boolean) {
     setIsStreaming(false);
   }, []);
 
-  // Inject a synthetic assistant message (for welcome message)
-  const injectMessage = useCallback((content: string) => {
-    setMessages([{
-      id: -2,
-      role: "assistant",
-      content,
-      createdAt: new Date().toISOString(),
-    }]);
-  }, []);
+  // Set a persisted welcome message (from POST /api/sommelier-chat/welcome)
+  const setWelcomeState = useCallback((chatId: number, msg: ChatMessage) => {
+    setActiveChatId(chatId);
+    setMessages([msg]);
+    queryClient.invalidateQueries({ queryKey: ["/api/sommelier-chat/list"] });
+  }, [queryClient]);
 
   const clearError = useCallback(() => setError(null), []);
 
@@ -341,7 +338,7 @@ export function useSommelierChat(isOpen: boolean) {
     startNewChat,
     cancelStream,
     retryMessage,
-    injectMessage,
+    setWelcomeState,
     clearError,
   };
 }

--- a/client/src/pages/HomeV2.tsx
+++ b/client/src/pages/HomeV2.tsx
@@ -192,6 +192,17 @@ export default function HomeV2() {
   const isAuthenticated = !!authData?.user;
   const user = authData?.user;
 
+  // Redirect new users (0 tastings, onboarding not done) to onboarding quiz
+  useEffect(() => {
+    if (
+      user &&
+      !user.onboardingCompleted &&
+      (user.tastingsCompleted ?? 0) === 0
+    ) {
+      setLocation("/onboarding");
+    }
+  }, [user, setLocation]);
+
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!email.trim()) return;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -52,11 +52,21 @@ export default function Login() {
       // Check if user exists by trying to fetch their dashboard data
       const response = await fetch(`/api/dashboard/${encodeURIComponent(email.trim())}?login=true`);
 
+      // Authenticate first regardless of whether user exists
+      const authResult = await login(email.trim());
+      if (!authResult.success) {
+        throw new Error(authResult.error || "Authentication failed");
+      }
+
       if (response.ok) {
-        // Authenticate with server to establish session
-        const authResult = await login(email.trim());
-        if (!authResult.success) {
-          throw new Error(authResult.error || "Authentication failed");
+        // Existing user with tasting history — check if onboarding completed
+        const authCheck = await fetch("/api/auth/me", { credentials: "include" });
+        const authInfo = await authCheck.json();
+
+        if (!authInfo.user?.onboardingCompleted) {
+          // Has history but never did onboarding — send through it
+          setLocation("/onboarding");
+          return;
         }
 
         // Redirect to original page or unified home
@@ -67,26 +77,8 @@ export default function Login() {
           description: redirectTo ? "Continuing where you left off..." : "Redirecting to your dashboard...",
         });
       } else if (response.status === 404) {
-        // User doesn't exist - authenticate to create account
-        const authResult = await login(email.trim());
-        if (!authResult.success) {
-          throw new Error(authResult.error || "Authentication failed");
-        }
-
-        // If they came from a journey, redirect back there
-        if (redirectTo?.startsWith('/journeys')) {
-          setLocation(redirectTo);
-          toast({
-            title: "Welcome!",
-            description: "You can start exploring wine journeys.",
-          });
-        } else {
-          toast({
-            title: "No Tasting History",
-            description: "You can start with solo tastings or learning journeys to build your profile.",
-          });
-          setLocation('/home');
-        }
+        // New user — always go through onboarding
+        setLocation("/onboarding");
       } else {
         throw new Error("Failed to check account");
       }

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useLocation, useSearch } from "wouter";
+import { useQueryClient } from "@tanstack/react-query";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,6 +14,7 @@ import { useAuth } from "@/hooks/useAuth";
 export default function Login() {
   const [, setLocation] = useLocation();
   const search = useSearch();
+  const queryClient = useQueryClient();
   const { toast } = useToast();
   const { login } = useAuth();
   const [email, setEmail] = useState("");
@@ -57,6 +59,9 @@ export default function Login() {
       if (!authResult.success) {
         throw new Error(authResult.error || "Authentication failed");
       }
+
+      // Clear stale auth cache from previous user so components fetch fresh data
+      queryClient.removeQueries({ queryKey: ["/api/auth/me"] });
 
       if (response.ok) {
         // Existing user with tasting history — check if onboarding completed

--- a/client/src/pages/OnboardingQuiz.tsx
+++ b/client/src/pages/OnboardingQuiz.tsx
@@ -403,8 +403,9 @@ export default function OnboardingQuiz() {
     },
     onSuccess: () => {
       justSaved.current = true;
+      sessionStorage.setItem("pierre_welcome", "true");
       queryClient.invalidateQueries({ queryKey: ["/api/auth/me"] });
-      setLocation("/home?pierre=welcome");
+      setLocation("/home");
     },
     onError: () => {
       setSaveError("Something went wrong. Please try again.");

--- a/client/src/pages/OnboardingQuiz.tsx
+++ b/client/src/pages/OnboardingQuiz.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useLocation } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { motion, AnimatePresence } from "framer-motion";
@@ -360,6 +360,7 @@ export default function OnboardingQuiz() {
     occasion: null,
   });
   const [saveError, setSaveError] = useState<string | null>(null);
+  const justSaved = useRef(false);
   const [, setLocation] = useLocation();
   const queryClient = useQueryClient();
 
@@ -378,7 +379,10 @@ export default function OnboardingQuiz() {
   });
 
   useEffect(() => {
-    if (authData?.user?.onboardingCompleted) {
+    // Redirect users who already completed onboarding away from quiz.
+    // Skip if we just saved — our onSuccess navigates to /home?pierre=welcome
+    // and we don't want this guard to override that with /home.
+    if (authData?.user?.onboardingCompleted && !justSaved.current) {
       setLocation("/home");
     }
   }, [authData, setLocation]);
@@ -397,6 +401,7 @@ export default function OnboardingQuiz() {
       return res.json();
     },
     onSuccess: () => {
+      justSaved.current = true;
       queryClient.invalidateQueries({ queryKey: ["/api/auth/me"] });
       setLocation("/home?pierre=welcome");
     },

--- a/client/src/pages/OnboardingQuiz.tsx
+++ b/client/src/pages/OnboardingQuiz.tsx
@@ -401,14 +401,16 @@ export default function OnboardingQuiz() {
       const res = await apiRequest("POST", "/api/user/onboarding", data);
       return res.json();
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       justSaved.current = true;
       sessionStorage.setItem("pierre_welcome", "true");
       // Update cache immediately so HomeV2 sees onboardingCompleted: true
-      // and doesn't redirect back to /onboarding (eliminates bounce delay)
+      // and doesn't redirect back to /onboarding (eliminates bounce delay).
+      // Include onboardingData so Pierre's welcome message is personalized.
+      const onboardingData = "skip" in variables ? null : variables;
       queryClient.setQueryData(["/api/auth/me"], (old: any) => {
         if (!old?.user) return old;
-        return { ...old, user: { ...old.user, onboardingCompleted: true } };
+        return { ...old, user: { ...old.user, onboardingCompleted: true, onboardingData } };
       });
       setLocation("/home");
     },

--- a/client/src/pages/OnboardingQuiz.tsx
+++ b/client/src/pages/OnboardingQuiz.tsx
@@ -404,7 +404,12 @@ export default function OnboardingQuiz() {
     onSuccess: () => {
       justSaved.current = true;
       sessionStorage.setItem("pierre_welcome", "true");
-      queryClient.invalidateQueries({ queryKey: ["/api/auth/me"] });
+      // Update cache immediately so HomeV2 sees onboardingCompleted: true
+      // and doesn't redirect back to /onboarding (eliminates bounce delay)
+      queryClient.setQueryData(["/api/auth/me"], (old: any) => {
+        if (!old?.user) return old;
+        return { ...old, user: { ...old.user, onboardingCompleted: true } };
+      });
       setLocation("/home");
     },
     onError: () => {

--- a/client/src/pages/OnboardingQuiz.tsx
+++ b/client/src/pages/OnboardingQuiz.tsx
@@ -1,0 +1,525 @@
+import { useState, useEffect } from "react";
+import { useLocation } from "wouter";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { motion, AnimatePresence } from "framer-motion";
+import { apiRequest } from "@/lib/queryClient";
+import { useHaptics } from "@/hooks/useHaptics";
+import { ArrowLeft, Loader2, Check } from "lucide-react";
+import type { User } from "@shared/schema";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+type QuizStep = "knowledge" | "vibe" | "food";
+
+interface QuizAnswers {
+  knowledgeLevel: string | null;
+  wineVibe: string | null;
+  foodPreferences: string[];
+}
+
+interface OptionCard {
+  value: string;
+  emoji: string;
+  title: string;
+  description: string;
+}
+
+// ============================================================================
+// QUIZ DATA
+// ============================================================================
+
+const KNOWLEDGE_OPTIONS: OptionCard[] = [
+  {
+    value: "beginner",
+    emoji: "\u{1F331}",
+    title: "I'm brand new",
+    description: "Never really explored wine",
+  },
+  {
+    value: "casual",
+    emoji: "\u{1F377}",
+    title: "I know what I like",
+    description: "I have favorites but couldn't tell you why",
+  },
+  {
+    value: "enthusiast",
+    emoji: "\u{1F4DA}",
+    title: "Getting into it",
+    description: "I read labels and ask questions at wine shops",
+  },
+  {
+    value: "nerd",
+    emoji: "\u{1F9E0}",
+    title: "Full wine nerd",
+    description: "I could talk terroir all day",
+  },
+];
+
+const VIBE_OPTIONS: OptionCard[] = [
+  {
+    value: "bold",
+    emoji: "\u{1F525}",
+    title: "Bold & Intense",
+    description: "Big reds, full body, wow factor",
+  },
+  {
+    value: "light",
+    emoji: "\u{1F338}",
+    title: "Light & Fresh",
+    description: "Crisp whites, delicate ros\u00E9s, easy-drinking",
+  },
+  {
+    value: "sweet",
+    emoji: "\u{1F36F}",
+    title: "Sweet & Fruity",
+    description: "Moscato, Riesling, fruit-forward wines",
+  },
+  {
+    value: "adventurous",
+    emoji: "\u{1F3B2}",
+    title: "Surprise me",
+    description: "I'll try anything once",
+  },
+];
+
+const FOOD_OPTIONS: OptionCard[] = [
+  { value: "italian", emoji: "\u{1F35D}", title: "Italian", description: "" },
+  { value: "sushi", emoji: "\u{1F363}", title: "Sushi", description: "" },
+  { value: "bbq", emoji: "\u{1F525}", title: "BBQ", description: "" },
+  { value: "cheese", emoji: "\u{1F9C0}", title: "Cheese", description: "" },
+  { value: "spicy", emoji: "\u{1F336}\uFE0F", title: "Spicy", description: "" },
+  { value: "seafood", emoji: "\u{1F990}", title: "Seafood", description: "" },
+  { value: "steak", emoji: "\u{1F969}", title: "Steak", description: "" },
+  { value: "veggie", emoji: "\u{1F957}", title: "Veggie", description: "" },
+];
+
+// ============================================================================
+// ANIMATION VARIANTS
+// ============================================================================
+
+const slideVariants = {
+  enter: (direction: number) => ({
+    x: direction > 0 ? 300 : -300,
+    opacity: 0,
+  }),
+  center: {
+    x: 0,
+    opacity: 1,
+  },
+  exit: (direction: number) => ({
+    x: direction < 0 ? 300 : -300,
+    opacity: 0,
+  }),
+};
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: { delay: i * 0.08, duration: 0.3 },
+  }),
+};
+
+// ============================================================================
+// STEP COMPONENTS
+// ============================================================================
+
+function StepHeader({
+  step,
+  totalSteps,
+  onBack,
+}: {
+  step: number;
+  totalSteps: number;
+  onBack?: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between px-1 mb-8">
+      {onBack ? (
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1 text-white/50 hover:text-white/80 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          <span className="text-sm">Back</span>
+        </button>
+      ) : (
+        <div />
+      )}
+      <div className="flex gap-1.5">
+        {Array.from({ length: totalSteps }, (_, i) => (
+          <div
+            key={i}
+            className={`h-1.5 rounded-full transition-all duration-300 ${
+              i < step
+                ? "w-6 bg-purple-500"
+                : i === step
+                  ? "w-6 bg-purple-400"
+                  : "w-3 bg-white/20"
+            }`}
+          />
+        ))}
+      </div>
+      <div className="text-white/40 text-sm">
+        {step + 1} of {totalSteps}
+      </div>
+    </div>
+  );
+}
+
+function SingleSelectStep({
+  title,
+  subtitle,
+  options,
+  selected,
+  onSelect,
+}: {
+  title: string;
+  subtitle: string;
+  options: OptionCard[];
+  selected: string | null;
+  onSelect: (value: string) => void;
+}) {
+  const { triggerHaptic } = useHaptics();
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-white mb-2">{title}</h1>
+      <p className="text-white/50 mb-8">{subtitle}</p>
+      <div className="space-y-3">
+        {options.map((option, i) => (
+          <motion.button
+            key={option.value}
+            custom={i}
+            variants={cardVariants}
+            initial="hidden"
+            animate="visible"
+            onClick={() => {
+              triggerHaptic("selection");
+              onSelect(option.value);
+            }}
+            className={`w-full text-left px-5 py-4 rounded-2xl border transition-all duration-200 ${
+              selected === option.value
+                ? "bg-purple-600/20 border-purple-500/50 shadow-lg shadow-purple-900/20"
+                : "bg-white/5 border-white/10 hover:bg-white/8 hover:border-white/20"
+            }`}
+          >
+            <div className="flex items-center gap-4">
+              <span className="text-2xl">{option.emoji}</span>
+              <div>
+                <span className="text-white font-medium block">
+                  {option.title}
+                </span>
+                <span className="text-white/40 text-sm">
+                  {option.description}
+                </span>
+              </div>
+              {selected === option.value && (
+                <Check className="w-5 h-5 text-purple-400 ml-auto" />
+              )}
+            </div>
+          </motion.button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MultiSelectStep({
+  title,
+  subtitle,
+  options,
+  selected,
+  onToggle,
+}: {
+  title: string;
+  subtitle: string;
+  options: OptionCard[];
+  selected: string[];
+  onToggle: (value: string) => void;
+}) {
+  const { triggerHaptic } = useHaptics();
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-white mb-2">{title}</h1>
+      <p className="text-white/50 mb-8">{subtitle}</p>
+      <div className="grid grid-cols-2 gap-3">
+        {options.map((option, i) => {
+          const isSelected = selected.includes(option.value);
+          return (
+            <motion.button
+              key={option.value}
+              custom={i}
+              variants={cardVariants}
+              initial="hidden"
+              animate="visible"
+              onClick={() => {
+                triggerHaptic("selection");
+                onToggle(option.value);
+              }}
+              className={`text-center px-4 py-5 rounded-2xl border transition-all duration-200 ${
+                isSelected
+                  ? "bg-purple-600/20 border-purple-500/50 shadow-lg shadow-purple-900/20"
+                  : "bg-white/5 border-white/10 hover:bg-white/8 hover:border-white/20"
+              }`}
+            >
+              <span className="text-3xl block mb-2">{option.emoji}</span>
+              <span className="text-white font-medium text-sm">
+                {option.title}
+              </span>
+              {isSelected && (
+                <Check className="w-4 h-4 text-purple-400 mx-auto mt-2" />
+              )}
+            </motion.button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// MAIN COMPONENT
+// ============================================================================
+
+export default function OnboardingQuiz() {
+  const [step, setStep] = useState<QuizStep>("knowledge");
+  const [direction, setDirection] = useState(1);
+  const [answers, setAnswers] = useState<QuizAnswers>({
+    knowledgeLevel: null,
+    wineVibe: null,
+    foodPreferences: [],
+  });
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [, setLocation] = useLocation();
+  const queryClient = useQueryClient();
+
+  // Auth check — redirect if already completed onboarding
+  const { data: authData, isLoading: authLoading } = useQuery<{
+    user: User & { onboardingCompleted: boolean };
+  }>({
+    queryKey: ["/api/auth/me"],
+    queryFn: async () => {
+      const res = await fetch("/api/auth/me", { credentials: "include" });
+      if (!res.ok) throw new Error("Not authenticated");
+      return res.json();
+    },
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  useEffect(() => {
+    if (authData?.user?.onboardingCompleted) {
+      setLocation("/home");
+    }
+  }, [authData, setLocation]);
+
+  // Redirect to login if not authenticated
+  useEffect(() => {
+    if (!authLoading && !authData?.user) {
+      setLocation("/home");
+    }
+  }, [authLoading, authData, setLocation]);
+
+  // Save mutation
+  const saveMutation = useMutation({
+    mutationFn: async (data: QuizAnswers | { skip: true }) => {
+      const res = await apiRequest("POST", "/api/user/onboarding", data);
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/auth/me"] });
+      setLocation("/home?pierre=welcome");
+    },
+    onError: () => {
+      setSaveError("Something went wrong. Please try again.");
+    },
+  });
+
+  // Step navigation
+  const steps: QuizStep[] = ["knowledge", "vibe", "food"];
+  const currentStepIndex = steps.indexOf(step);
+
+  const goNext = () => {
+    const nextIndex = currentStepIndex + 1;
+    if (nextIndex < steps.length) {
+      setDirection(1);
+      setStep(steps[nextIndex]);
+    }
+  };
+
+  const goBack = () => {
+    const prevIndex = currentStepIndex - 1;
+    if (prevIndex >= 0) {
+      setDirection(-1);
+      setStep(steps[prevIndex]);
+    }
+  };
+
+  const handleComplete = () => {
+    setSaveError(null);
+    saveMutation.mutate(answers);
+  };
+
+  const handleSkip = () => {
+    setSaveError(null);
+    saveMutation.mutate({ skip: true });
+  };
+
+  const toggleFood = (value: string) => {
+    setAnswers((prev) => ({
+      ...prev,
+      foodPreferences: prev.foodPreferences.includes(value)
+        ? prev.foodPreferences.filter((f) => f !== value)
+        : [...prev.foodPreferences, value],
+    }));
+  };
+
+  // Loading state
+  if (authLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-primary flex items-center justify-center">
+        <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-primary flex flex-col">
+      <div className="flex-1 flex flex-col max-w-md mx-auto w-full px-6 py-8">
+        <StepHeader
+          step={currentStepIndex}
+          totalSteps={steps.length}
+          onBack={currentStepIndex > 0 ? goBack : undefined}
+        />
+
+        <div className="flex-1 relative overflow-hidden">
+          <AnimatePresence mode="wait" custom={direction}>
+            {step === "knowledge" && (
+              <motion.div
+                key="knowledge"
+                custom={direction}
+                variants={slideVariants}
+                initial="enter"
+                animate="center"
+                exit="exit"
+                transition={{ duration: 0.25, ease: "easeInOut" }}
+              >
+                <SingleSelectStep
+                  title="Let's get to know you"
+                  subtitle="How much do you know about wine?"
+                  options={KNOWLEDGE_OPTIONS}
+                  selected={answers.knowledgeLevel}
+                  onSelect={(value) => {
+                    setAnswers((prev) => ({
+                      ...prev,
+                      knowledgeLevel: value,
+                    }));
+                    // Auto-advance after selection with a small delay
+                    setTimeout(() => {
+                      setDirection(1);
+                      setStep("vibe");
+                    }, 300);
+                  }}
+                />
+              </motion.div>
+            )}
+
+            {step === "vibe" && (
+              <motion.div
+                key="vibe"
+                custom={direction}
+                variants={slideVariants}
+                initial="enter"
+                animate="center"
+                exit="exit"
+                transition={{ duration: 0.25, ease: "easeInOut" }}
+              >
+                <SingleSelectStep
+                  title="What's your style?"
+                  subtitle="Pick what sounds most like you"
+                  options={VIBE_OPTIONS}
+                  selected={answers.wineVibe}
+                  onSelect={(value) => {
+                    setAnswers((prev) => ({ ...prev, wineVibe: value }));
+                    // Auto-advance after selection
+                    setTimeout(() => {
+                      setDirection(1);
+                      setStep("food");
+                    }, 300);
+                  }}
+                />
+              </motion.div>
+            )}
+
+            {step === "food" && (
+              <motion.div
+                key="food"
+                custom={direction}
+                variants={slideVariants}
+                initial="enter"
+                animate="center"
+                exit="exit"
+                transition={{ duration: 0.25, ease: "easeInOut" }}
+              >
+                <MultiSelectStep
+                  title="What do you love to eat?"
+                  subtitle="Pick all that apply — helps us pair wines for you"
+                  options={FOOD_OPTIONS}
+                  selected={answers.foodPreferences}
+                  onToggle={toggleFood}
+                />
+
+                {/* Complete button */}
+                <motion.button
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.4 }}
+                  onClick={handleComplete}
+                  disabled={
+                    saveMutation.isPending ||
+                    answers.foodPreferences.length === 0
+                  }
+                  className="w-full mt-8 py-4 rounded-2xl font-semibold text-white transition-all duration-200 disabled:opacity-40 bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 active:scale-[0.98]"
+                >
+                  {saveMutation.isPending ? (
+                    <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+                  ) : (
+                    "Let's go!"
+                  )}
+                </motion.button>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
+        {/* Error message */}
+        {saveError && (
+          <motion.p
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="text-red-400 text-sm text-center mt-4"
+          >
+            {saveError}
+          </motion.p>
+        )}
+
+        {/* Skip link */}
+        <motion.button
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.5 }}
+          onClick={handleSkip}
+          disabled={saveMutation.isPending}
+          className="text-white/30 hover:text-white/50 text-sm py-4 transition-colors"
+        >
+          Skip for now
+        </motion.button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/OnboardingQuiz.tsx
+++ b/client/src/pages/OnboardingQuiz.tsx
@@ -376,6 +376,7 @@ export default function OnboardingQuiz() {
     },
     retry: false,
     staleTime: 5 * 60 * 1000,
+    refetchOnMount: "always",
   });
 
   useEffect(() => {

--- a/docs/plans/2026-02-16-feat-hybrid-onboarding-flow-plan.md
+++ b/docs/plans/2026-02-16-feat-hybrid-onboarding-flow-plan.md
@@ -1,0 +1,671 @@
+---
+title: "feat: Hybrid onboarding flow (quiz + Pierre handoff)"
+type: feat
+date: 2026-02-16
+---
+
+# feat: Hybrid Onboarding Flow
+
+## Overview
+
+New users currently land on an empty home screen with zero guidance. This feature adds a delightful hybrid onboarding: a quick 3-screen interactive quiz captures basic preferences, then Pierre (the AI sommelier) greets them with personalized context and recommends a first journey + bottle.
+
+The goal: **within 60 seconds of signing up, the user feels like the app already knows them.**
+
+## Problem Statement
+
+Today's first-time user experience:
+1. User enters email on `/home` login form
+2. Server creates account with defaults (`tastingLevel: 'intro'`, `wineArchetype: null`)
+3. User sees empty Solo tab — 0 tastings, no active journey, blank preference bars
+4. Pierre FAB is visible but has no context to personalize with
+5. User has no idea what to do first
+
+This is the classic cold-start problem. The app feels hollow until you've done your first tasting, but there's no guidance toward that first tasting.
+
+## Proposed Solution: Approach C (Hybrid)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  PHASE 1: Quick Quiz (3 screens, ~30 seconds)               │
+│                                                              │
+│  Screen 1: "How much do you know about wine?"               │
+│  Screen 2: "What's your style?"                              │
+│  Screen 3: "What do you love to eat?"                        │
+│                                                              │
+├─────────────────────────────────────────────────────────────┤
+│  PHASE 2: Pierre Handoff                                     │
+│                                                              │
+│  → Save quiz answers to users table                          │
+│  → Redirect to /home                                         │
+│  → Auto-open Pierre with onboarding context                  │
+│  → Pierre greets with personalized welcome + recommends      │
+│    first journey + first bottle                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Why Hybrid?
+
+| Approach | Pro | Con |
+|----------|-----|-----|
+| A: Pure conversational (Pierre-only) | Magical feel | Hard to extract structured data reliably, longer, users may not engage |
+| B: Pure quiz | Fast, structured data clean | Generic app feel, less unique |
+| **C: Hybrid (quiz + Pierre)** | **Quick structured capture + magical AI moment** | **Slightly more complex (two UIs)** |
+
+The quiz handles data capture reliably. Pierre handles the magic. Each does what it's best at.
+
+## Technical Approach
+
+### Architecture Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ FRONTEND                                                          │
+│                                                                    │
+│  App.tsx                                                           │
+│   ├─ Route: /onboarding → <OnboardingQuiz />                     │
+│   └─ SommelierFAB (hidden on /onboarding, auto-opens after)      │
+│                                                                    │
+│  HomeV2.tsx                                                        │
+│   └─ After auth: if (!user.onboardingCompleted) redirect          │
+│                                                                    │
+│  pages/OnboardingQuiz.tsx                                          │
+│   ├─ Step 1: KnowledgeLevel                                       │
+│   ├─ Step 2: WineVibe                                              │
+│   ├─ Step 3: FoodPreferences                                      │
+│   └─ Completion: POST /api/user/onboarding → redirect /home       │
+│                                                                    │
+├──────────────────────────────────────────────────────────────────┤
+│ BACKEND                                                            │
+│                                                                    │
+│  routes/user.ts (NEW)                                              │
+│   └─ POST /api/user/onboarding   → save preferences, return user  │
+│                                                                    │
+│  routes/auth.ts                                                    │
+│   └─ GET /api/auth/me  → add onboardingCompleted to response      │
+│                                                                    │
+│  services/sommelierContextBuilder.ts                               │
+│   └─ buildUserContext() → add onboarding profile section           │
+│                                                                    │
+├──────────────────────────────────────────────────────────────────┤
+│ DATABASE                                                           │
+│                                                                    │
+│  shared/schema.ts → users table                                    │
+│   + onboardingCompleted: boolean (default false)                   │
+│   + onboardingData: jsonb (quiz answers blob)                      │
+│                                                                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Phase 1: Schema + API
+
+#### 1a. Add onboarding fields to `users` table
+
+**File:** `shared/schema.ts:647-659`
+
+Add two columns to the `users` table:
+
+```typescript
+// In the users pgTable definition:
+onboardingCompleted: boolean("onboarding_completed").default(false).notNull(),
+onboardingData: jsonb("onboarding_data"),  // { knowledgeLevel, wineVibe, foodPreferences }
+```
+
+**Why `onboardingData` as JSONB instead of separate columns?**
+- Quiz questions may evolve (we might add/remove questions)
+- JSONB is flexible — no schema migration needed when quiz changes
+- Single column to read/write, simpler API
+- Pierre's context builder can read the blob directly
+
+**Type definition** (add to schema.ts):
+
+```typescript
+export interface OnboardingData {
+  knowledgeLevel: 'beginner' | 'casual' | 'enthusiast' | 'nerd';
+  wineVibe: 'bold' | 'light' | 'sweet' | 'adventurous';
+  foodPreferences: string[];  // ['italian', 'sushi', 'bbq', 'spicy', 'cheese', 'seafood']
+  completedAt: string;  // ISO timestamp
+}
+```
+
+Run `npm run db:push` to sync.
+
+#### 1b. Update `/api/auth/me` response
+
+**File:** `server/routes/auth.ts:246-256`
+
+Add `onboardingCompleted` to the response:
+
+```typescript
+return res.json({
+  user: {
+    id: user.id,
+    email: user.email,
+    createdAt: user.createdAt,
+    tastingLevel: user.tastingLevel,
+    tastingsCompleted: user.tastingsCompleted,
+    levelUpPromptEligible: user.levelUpPromptEligible,
+    onboardingCompleted: user.onboardingCompleted,  // ADD THIS
+  }
+});
+```
+
+#### 1c. Create onboarding save endpoint
+
+**New file:** `server/routes/user.ts`
+
+```typescript
+import { Express, Request, Response } from "express";
+import { requireAuth } from "./auth";
+import { db } from "../db";
+import { users } from "@shared/schema";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+const onboardingSchema = z.object({
+  knowledgeLevel: z.enum(['beginner', 'casual', 'enthusiast', 'nerd']),
+  wineVibe: z.enum(['bold', 'light', 'sweet', 'adventurous']),
+  foodPreferences: z.array(z.string()).min(1).max(10),
+});
+
+export function registerUserRoutes(app: Express): void {
+  app.post("/api/user/onboarding", requireAuth, async (req: Request, res: Response) => {
+    const userId = req.session.userId!;
+
+    const parsed = onboardingSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid onboarding data", details: parsed.error.flatten() });
+    }
+
+    const { knowledgeLevel, wineVibe, foodPreferences } = parsed.data;
+
+    // Map quiz answers to tastingLevel
+    const tastingLevelMap: Record<string, string> = {
+      beginner: 'intro',
+      casual: 'intro',
+      enthusiast: 'intermediate',
+      nerd: 'advanced',
+    };
+
+    await db.update(users).set({
+      onboardingCompleted: true,
+      onboardingData: {
+        knowledgeLevel,
+        wineVibe,
+        foodPreferences,
+        completedAt: new Date().toISOString(),
+      },
+      tastingLevel: tastingLevelMap[knowledgeLevel],
+    }).where(eq(users.id, userId));
+
+    // Return updated user
+    const updatedUser = await db.query.users.findFirst({
+      where: eq(users.id, userId),
+    });
+
+    return res.json({ user: updatedUser });
+  });
+}
+```
+
+Register in `server/routes.ts` alongside other route registrations.
+
+### Phase 2: Onboarding Quiz UI
+
+**New file:** `client/src/pages/OnboardingQuiz.tsx`
+
+#### Quiz Screen Design
+
+Each screen is a full-page dark UI with large tappable cards. No text inputs — everything is tap-to-select. Animated transitions between screens with `AnimatePresence`.
+
+**Screen 1: Knowledge Level**
+```
+┌──────────────────────────────────┐
+│                                   │
+│   🍷  Let's get to know you      │
+│                                   │
+│   How much do you know            │
+│   about wine?                     │
+│                                   │
+│  ┌─────────────────────────────┐  │
+│  │  🌱  I'm brand new          │  │
+│  │  Never really explored wine  │  │
+│  └─────────────────────────────┘  │
+│  ┌─────────────────────────────┐  │
+│  │  🍷  I know what I like     │  │
+│  │  I have favorites but        │  │
+│  │  couldn't tell you why       │  │
+│  └─────────────────────────────┘  │
+│  ┌─────────────────────────────┐  │
+│  │  📚  Getting into it         │  │
+│  │  I read labels and ask       │  │
+│  │  questions at wine shops     │  │
+│  └─────────────────────────────┘  │
+│  ┌─────────────────────────────┐  │
+│  │  🧠  Full wine nerd          │  │
+│  │  I could talk terroir        │  │
+│  │  all day                     │  │
+│  └─────────────────────────────┘  │
+│                                   │
+│  ───────── Skip for now ──────── │
+│                                   │
+└──────────────────────────────────┘
+```
+
+**Screen 2: Wine Vibe**
+```
+┌──────────────────────────────────┐
+│  ← Back              2 of 3      │
+│                                   │
+│   What's your style?              │
+│   Pick what sounds most like you  │
+│                                   │
+│  ┌─────────────────────────────┐  │
+│  │  🔥  Bold & Intense         │  │
+│  │  Big reds, full body, wow   │  │
+│  └─────────────────────────────┘  │
+│  ┌─────────────────────────────┐  │
+│  │  🌸  Light & Fresh          │  │
+│  │  Crisp whites, delicate     │  │
+│  │  rosés, easy-drinking       │  │
+│  └─────────────────────────────┘  │
+│  ┌─────────────────────────────┐  │
+│  │  🍯  Sweet & Fruity         │  │
+│  │  Moscato, Riesling, dessert │  │
+│  │  wines, fruit-forward       │  │
+│  └─────────────────────────────┘  │
+│  ┌─────────────────────────────┐  │
+│  │  🎲  Surprise me            │  │
+│  │  I'll try anything once     │  │
+│  └─────────────────────────────┘  │
+│                                   │
+│  ───────── Skip for now ──────── │
+│                                   │
+└──────────────────────────────────┘
+```
+
+**Screen 3: Food Preferences (multi-select)**
+```
+┌──────────────────────────────────┐
+│  ← Back              3 of 3      │
+│                                   │
+│   What do you love to eat?        │
+│   Pick all that apply             │
+│                                   │
+│  ┌────────┐  ┌────────┐          │
+│  │ 🍝     │  │ 🍣     │          │
+│  │Italian │  │ Sushi  │          │
+│  └────────┘  └────────┘          │
+│  ┌────────┐  ┌────────┐          │
+│  │ 🔥     │  │ 🧀     │          │
+│  │ BBQ    │  │Cheese  │          │
+│  └────────┘  └────────┘          │
+│  ┌────────┐  ┌────────┐          │
+│  │ 🌶️     │  │ 🦐     │          │
+│  │ Spicy  │  │Seafood │          │
+│  └────────┘  └────────┘          │
+│  ┌────────┐  ┌────────┐          │
+│  │ 🥩     │  │ 🥗     │          │
+│  │ Steak  │  │ Veggie │          │
+│  └────────┘  └────────┘          │
+│                                   │
+│  ┌─────────────────────────────┐  │
+│  │  Let's go! →                 │  │
+│  └─────────────────────────────┘  │
+│                                   │
+│  ───────── Skip for now ──────── │
+│                                   │
+└──────────────────────────────────┘
+```
+
+#### Quiz Component Pattern
+
+Use the established multi-step view state pattern from `SoloTastingNew.tsx:61`:
+
+```typescript
+type QuizStep = 'knowledge' | 'vibe' | 'food';
+
+export default function OnboardingQuiz() {
+  const [step, setStep] = useState<QuizStep>('knowledge');
+  const [answers, setAnswers] = useState({
+    knowledgeLevel: null as string | null,
+    wineVibe: null as string | null,
+    foodPreferences: [] as string[],
+  });
+  const [, setLocation] = useLocation();
+  const queryClient = useQueryClient();
+
+  const saveMutation = useMutation({
+    mutationFn: async (data: typeof answers) => {
+      const res = await apiRequest("POST", "/api/user/onboarding", data);
+      if (!res.ok) throw new Error("Failed to save");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/auth/me"] });
+      setLocation("/home?pierre=welcome");
+    },
+    onError: (error) => {
+      // Show error toast, don't fake success (learnings from past bugs)
+    },
+  });
+
+  const handleSkip = () => {
+    // Skip saves onboardingCompleted=true with null data
+    // so user isn't asked again
+    saveMutation.mutate({
+      knowledgeLevel: null,
+      wineVibe: null,
+      foodPreferences: [],
+    });
+  };
+
+  // AnimatePresence wraps each step with slide transitions
+  return (
+    <div className="min-h-screen bg-gradient-primary">
+      <AnimatePresence mode="wait">
+        {step === 'knowledge' && <KnowledgeStep ... />}
+        {step === 'vibe' && <VibeStep ... />}
+        {step === 'food' && <FoodStep ... />}
+      </AnimatePresence>
+    </div>
+  );
+}
+```
+
+**Animation pattern** (slide left/right with Framer Motion):
+```typescript
+const slideVariants = {
+  enter: (direction: number) => ({
+    x: direction > 0 ? 300 : -300,
+    opacity: 0,
+  }),
+  center: { x: 0, opacity: 1 },
+  exit: (direction: number) => ({
+    x: direction < 0 ? 300 : -300,
+    opacity: 0,
+  }),
+};
+```
+
+### Phase 3: First-Time User Detection + Routing
+
+#### 3a. Redirect logic in HomeV2
+
+**File:** `client/src/pages/HomeV2.tsx:192-228`
+
+After auth check resolves, redirect new users:
+
+```typescript
+const isAuthenticated = !!authData?.user;
+const user = authData?.user;
+
+// Redirect new users to onboarding
+useEffect(() => {
+  if (user && !user.onboardingCompleted) {
+    setLocation("/onboarding");
+  }
+}, [user, setLocation]);
+```
+
+#### 3b. Register onboarding route
+
+**File:** `client/src/App.tsx`
+
+```typescript
+// Add to lazy imports
+const OnboardingQuiz = lazy(() => import("@/pages/OnboardingQuiz"));
+
+// Add route (before /home route)
+<Route path="/onboarding" component={OnboardingQuiz} />
+```
+
+#### 3c. Hide Pierre FAB during onboarding
+
+**File:** `client/src/components/sommelier/SommelierFAB.tsx:9`
+
+Add `/onboarding` to hidden routes:
+
+```typescript
+const HIDDEN_ROUTE_PATTERNS = [
+  /^\/onboarding$/,  // ADD THIS
+  /^\/tasting\/[^/]+\/[^/]+$/,
+  /^\/tasting\/new$/,
+  /^\/solo\/new$/,
+  /^\/completion\//,
+  /^\/host\//,
+];
+```
+
+#### 3d. Guard against re-visiting /onboarding
+
+In `OnboardingQuiz.tsx`, if user has already completed onboarding, redirect to home:
+
+```typescript
+const { data: authData } = useQuery<{ user: User }>({
+  queryKey: ["/api/auth/me"],
+  // ...
+});
+
+useEffect(() => {
+  if (authData?.user?.onboardingCompleted) {
+    setLocation("/home");
+  }
+}, [authData]);
+```
+
+### Phase 4: Pierre Context Enrichment
+
+#### 4a. Enrich system prompt with onboarding data
+
+**File:** `server/services/sommelierContextBuilder.ts:52-92`
+
+In `buildUserContext()`, after the existing `wineArchetype` line:
+
+```typescript
+// Onboarding profile (if completed)
+if (user.onboardingData) {
+  const ob = user.onboardingData as OnboardingData;
+  const vibeMap: Record<string, string> = {
+    bold: "bold, full-bodied wines",
+    light: "light, crisp wines",
+    sweet: "sweet, fruit-forward wines",
+    adventurous: "trying new and unusual wines",
+  };
+  const knowledgeMap: Record<string, string> = {
+    beginner: "brand new to wine",
+    casual: "drinks wine casually, knows what they like",
+    enthusiast: "actively learning about wine",
+    nerd: "serious wine knowledge",
+  };
+  lines.push(`Self-described: ${knowledgeMap[ob.knowledgeLevel] || ob.knowledgeLevel}`);
+  lines.push(`Style preference: ${vibeMap[ob.wineVibe] || ob.wineVibe}`);
+  if (ob.foodPreferences?.length > 0) {
+    lines.push(`Favorite foods: ${ob.foodPreferences.join(", ")}`);
+  }
+}
+```
+
+This means Pierre will **automatically** have onboarding context from the very first chat, with zero additional API work.
+
+#### 4b. Pierre auto-open with welcome message
+
+**File:** `client/src/components/sommelier/SommelierFAB.tsx`
+
+Detect `?pierre=welcome` query param and auto-open:
+
+```typescript
+export function SommelierFAB() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [location] = useLocation();
+
+  // Auto-open Pierre after onboarding
+  useEffect(() => {
+    if (location.includes("pierre=welcome")) {
+      // Small delay so home page renders first
+      const timer = setTimeout(() => setIsOpen(true), 500);
+      return () => clearTimeout(timer);
+    }
+  }, [location]);
+
+  // ... rest unchanged
+}
+```
+
+When Pierre opens after onboarding, the `WelcomeState` component in `SommelierChatSheet` will show. The user can then type anything or use a suggested prompt, and Pierre will already have their onboarding context in the system prompt.
+
+**Alternative (nicer UX):** Pre-populate Pierre with a first message that references the quiz. This requires the frontend to auto-send a message like "I just finished the onboarding quiz — what should I try first?" when `?pierre=welcome` is detected. The `useSommelierChat` hook's `sendMessage` function can handle this.
+
+### Phase 5: Handle Existing Users (Migration)
+
+Users who signed up before onboarding was built will have `onboardingCompleted: false` by default.
+
+**Decision:** Existing users should NOT be forced into onboarding if they already have tasting history.
+
+Add to the redirect logic in `HomeV2.tsx`:
+
+```typescript
+useEffect(() => {
+  if (user && !user.onboardingCompleted && user.tastingsCompleted === 0) {
+    setLocation("/onboarding");
+  }
+}, [user, setLocation]);
+```
+
+This means: only redirect to onboarding if the user has **never** completed a tasting. Users who signed up before and already have history skip straight to home.
+
+## Edge Cases & Mitigations
+
+| Edge Case | Mitigation |
+|-----------|------------|
+| **Browser closed mid-quiz** | Quiz state is local React state (not persisted). User returns to /home, gets redirected back to /onboarding, starts fresh. Quiz is ~30 seconds so restart is acceptable. |
+| **User completes onboarding, navigates back to /onboarding** | Guard check: if `onboardingCompleted === true`, redirect to /home. |
+| **Pierre API fails on handoff** | Pierre handles this already — `SommelierChatSheet` has error/retry states. User still lands on home with quiz data saved; they can open Pierre whenever. |
+| **No journeys match user preferences** | Pierre falls back to recommending the most popular beginner journey. The static recommendation tables + GPT fallback in `wineRecommendations.ts` handle this. |
+| **Existing users (pre-onboarding)** | Only redirect if `tastingsCompleted === 0`. Users with history skip onboarding. |
+| **User changes preferences later** | v1: No UI for re-doing quiz. Pierre learns from actual tasting data over time, which supersedes quiz answers. Onboarding data is the "cold start" signal only. |
+| **Skip flow** | Saves `onboardingCompleted: true` with no data. User is never asked again. Pierre has no onboarding context but that's fine — same as today. |
+| **User is on desktop** | Same quiz but rendered in a wider layout. No changes needed — Tailwind responsive classes handle this (`max-w-md mx-auto` centers the quiz on desktop). |
+| **Network error during save** | Show error toast + retry button (learned from past silent-data-loss bugs). Don't redirect until save succeeds. |
+| **Multiple tabs** | TanStack Query's `staleTime` handles this — all tabs share the `/api/auth/me` cache. Once one tab saves onboarding, the other detects the change on next refetch. |
+
+## Acceptance Criteria
+
+### Functional Requirements
+- [x] New users (0 tastings) are redirected to `/onboarding` after login
+- [x] Quiz has 3 screens: knowledge level, wine vibe, food preferences
+- [x] Each screen has clear, tappable options (no text input required)
+- [x] Back navigation works between quiz screens
+- [x] "Skip for now" is available on every screen, saves and completes without data
+- [x] Quiz answers are saved to database on completion
+- [x] User is redirected to `/home` after completion
+- [x] Pierre auto-opens on `/home` after onboarding
+- [x] Pierre's system prompt includes onboarding data
+- [x] Existing users with tasting history skip onboarding
+- [x] Completing onboarding prevents re-visiting `/onboarding`
+- [x] Pierre FAB is hidden during onboarding
+
+### Non-Functional Requirements
+- [ ] Quiz loads in < 1 second (lazy-loaded, no API calls until save)
+- [ ] Animations are smooth (60fps) on mobile
+- [ ] Accessible: keyboard navigation works, screen reader labels present
+- [ ] Save mutation includes proper error handling with retry
+
+### Quality Gates
+- [ ] Manual test: new user signup → quiz → Pierre greeting flow works end-to-end
+- [ ] Manual test: existing user with tastings → skips onboarding
+- [ ] Manual test: skip flow → saves correctly, doesn't loop
+- [ ] Manual test: mobile Safari + Chrome
+- [x] `npm run check` passes (TypeScript)
+
+## Implementation Phases
+
+### Phase 1: Schema + API (~30 min)
+1. Add `onboardingCompleted` + `onboardingData` to `users` in `shared/schema.ts`
+2. Run `npm run db:push`
+3. Update `/api/auth/me` to return `onboardingCompleted`
+4. Create `POST /api/user/onboarding` in new `server/routes/user.ts`
+5. Register routes in `server/routes.ts`
+
+### Phase 2: Quiz UI (~1-2 hours)
+1. Create `client/src/pages/OnboardingQuiz.tsx` with 3 quiz steps
+2. Build step components: `KnowledgeStep`, `VibeStep`, `FoodStep`
+3. Add animated transitions between steps
+4. Add skip flow
+5. Wire up save mutation
+6. Add `/onboarding` route to `App.tsx`
+
+### Phase 3: Routing + Detection (~30 min)
+1. Add redirect logic to `HomeV2.tsx` (check `onboardingCompleted` + `tastingsCompleted`)
+2. Add `/onboarding` to `HIDDEN_ROUTE_PATTERNS` in `SommelierFAB.tsx`
+3. Add guard in `OnboardingQuiz.tsx` to redirect if already completed
+
+### Phase 4: Pierre Integration (~30 min)
+1. Enrich `buildUserContext()` in `sommelierContextBuilder.ts` with onboarding data
+2. Add `?pierre=welcome` auto-open logic to `SommelierFAB.tsx`
+3. Optionally: auto-send first message to Pierre after onboarding
+
+### Phase 5: Polish + Test (~30 min)
+1. Mobile testing (Safari, Chrome)
+2. Desktop layout verification
+3. Edge case testing (skip, back, close-reopen)
+4. Haptic feedback on card taps
+5. Progress indicator (dots or "1 of 3")
+
+## Files Changed
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `client/src/pages/OnboardingQuiz.tsx` | Quiz page with 3 steps |
+| `server/routes/user.ts` | User profile endpoints (onboarding save) |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `shared/schema.ts` | Add `onboardingCompleted` + `onboardingData` to users table |
+| `server/routes/auth.ts:246-256` | Add `onboardingCompleted` to `/api/auth/me` response |
+| `server/routes.ts` | Register new user routes |
+| `client/src/App.tsx:16,41` | Add lazy import + route for OnboardingQuiz |
+| `client/src/pages/HomeV2.tsx:192` | Add redirect logic for first-time users |
+| `client/src/components/sommelier/SommelierFAB.tsx:9,56` | Hide on /onboarding + auto-open after |
+| `server/services/sommelierContextBuilder.ts:52` | Add onboarding data to Pierre's context |
+
+## ERD Changes
+
+```mermaid
+erDiagram
+    users {
+        serial id PK
+        varchar email UK
+        timestamp created_at
+        varchar tasting_level
+        integer tastings_completed
+        boolean level_up_prompt_eligible
+        varchar wine_archetype
+        boolean onboarding_completed "NEW - default false"
+        jsonb onboarding_data "NEW - quiz answers blob"
+    }
+
+    users ||--o{ tastings : "has many"
+    users ||--o{ user_journeys : "enrolled in"
+    users ||--o{ sommelier_chats : "chats with Pierre"
+```
+
+## References
+
+### Internal
+- `shared/schema.ts:647-659` — users table definition
+- `server/routes/auth.ts:231-261` — `/api/auth/me` endpoint
+- `server/services/sommelierContextBuilder.ts:41-97` — Pierre context builder
+- `client/src/components/sommelier/SommelierFAB.tsx:1-114` — Pierre FAB component
+- `client/src/pages/HomeV2.tsx:174-228` — Auth check + login flow
+- `client/src/App.tsx:39-95` — Route registration
+- `client/src/pages/SoloTastingNew.tsx:61` — Multi-step view state pattern
+
+### Institutional Learnings Applied
+- State preservation: close != reset (from `docs/solutions/ui-bugs/state-loss-accidental-dismiss-pierre-chat-20260215.md`)
+- Never fake success on save errors (from `docs/solutions/logic-errors/silent-data-loss-solo-tasting-saves-20260215.md`)
+- Always `invalidateQueries` after mutations (from same source)
+- Use `handleOnly` on Vaul drawers (from same source)
+- Auth consistency via shared `queryKey: ["/api/auth/me"]` (from `docs/solutions/integration-issues/auth-chat-state-sync-race-condition-20260214.md`)

--- a/docs/plans/2026-02-17-feat-enhanced-onboarding-with-pierre-tutorial-plan.md
+++ b/docs/plans/2026-02-17-feat-enhanced-onboarding-with-pierre-tutorial-plan.md
@@ -1,0 +1,284 @@
+---
+title: "feat: Enhanced Onboarding with Pierre Tutorial Handoff"
+type: feat
+date: 2026-02-17
+---
+
+# Enhanced Onboarding with Pierre Tutorial Handoff
+
+## Overview
+
+The current onboarding (3 quick quiz screens) collects basic preferences but fails at the critical job: **teaching users what they can do in the app**. The #1 feedback from early users is "I didn't know what to do when I got in." This plan enhances the quiz to feel more personalized and adds a Pierre welcome message that serves as an interactive app tutorial with hot links.
+
+## Problem Statement
+
+1. **Quiz is too thin** — 3 taps and you're done. Doesn't feel like the app is getting to know you.
+2. **No escape hatches** — Every question forces a wine-specific answer. New users who don't know wine feel pressured.
+3. **No palate discovery** — We only ask about wine and food, missing an opportunity to understand taste preferences through non-wine drinks they already know.
+4. **Pierre handoff is broken** — After the quiz, Pierre auto-opens but shows the generic `WelcomeState` (camera CTA + 2 suggested prompts). There's no personalized first message, no mention of quiz answers, no app orientation.
+5. **No app tour** — Users land on `/home` with no guidance on what to do first. The three pillars (Solo, Group, Dashboard) go unexplained.
+
+## Proposed Solution
+
+### Part 1: Richer Quiz (5 screens instead of 3)
+
+**Screen 1: Wine Knowledge** (existing, modified)
+- Add "Not sure yet" option with shrug emoji
+- Keep auto-advance behavior
+
+**Screen 2: Wine Style** (existing, modified)
+- Add "Not sure yet" option
+- Keep auto-advance behavior
+
+**Screen 3: "What flavors do you reach for?"** (existing food screen, reframed)
+- Change title: "What do you love to eat?" → **"What flavors do you reach for?"**
+- Change subtitle: "Pick all that apply — helps us pair wines" → **"Your food taste tells us a lot about wines you'll love"**
+- Add 3 more options: "Chocolate/Desserts", "Fresh/Salads", "Comfort Food"
+- Allow 0 selections (remove the min-1 requirement, make Continue button always enabled)
+
+**Screen 4: "What do you usually drink?"** (NEW)
+- Title: **"What do you usually drink?"**
+- Subtitle: **"This tells us more about your palate than you'd think"**
+- Multi-select grid (same layout as food), options:
+  - Coffee (black), Iced Latte, Tea, Sparkling Water, Apple Juice, Lemonade, Cola, Kombucha
+- Allow 0 selections (skip-friendly)
+- These map to wine palate profiles in the context builder (see backend section)
+
+**Screen 5: "What brings you here?"** (NEW)
+- Title: **"What brings you here?"**
+- Subtitle: **"Helps Pierre give you the right kind of advice"**
+- Single-select with "Not sure yet" option:
+  - "Learning for fun" — I just want to know more about wine
+  - "Finding my go-to bottle" — I want a reliable everyday pick
+  - "Impressing at dinners" — I want to sound smart at restaurants
+  - "Date night picks" — I need wine for special occasions
+  - "Not sure yet" — I'm just exploring
+
+### Part 2: Pierre Welcome Message (the tutorial)
+
+After quiz completion, instead of showing the generic `WelcomeState`:
+
+1. **Inject a synthetic assistant message** into `useSommelierChat` state when opened via `?pierre=welcome`
+2. This message is **not an API call** — it's a pre-built markdown string assembled client-side from the user's quiz answers
+3. The message contains **hot links** (in-app markdown links that trigger SPA navigation)
+
+**Example welcome message** (for a user who picked: casual knowledge, bold wines, Italian food, black coffee, "finding my go-to bottle"):
+
+> Hey! I'm Pierre, your personal wine guide. You like bold flavors and Italian food? We're going to get along.
+>
+> Cata isn't a wine textbook — it's about discovering what **you** like. Here's how:
+>
+> - **[Taste a wine](/tasting/new)** — snap any bottle, then answer a few fun questions about what you're tasting. Our system learns what you love (and what you don't) to make better picks for you over time.
+> - **[Learning Journeys](/journeys)** — guided tastings that build your palate step by step. Each journey is a few wines with questions designed by a sommelier.
+> - **[Group tastings](/home/group)** — host a tasting night with friends. Pick a curated set of wines, everyone tastes together, and you compare notes live.
+> - **[Your taste profile](/home/dashboard)** — watch your palate evolve as you taste more. The more you drink, the smarter your recommendations get.
+>
+> Since you want to find a go-to bottle, I'd start by **[tasting whatever you're drinking right now](/tasting/new)** — even if it's just Tuesday night wine. That's how we start learning what clicks for you.
+>
+> Or just ask me anything. What sounds good?
+
+### Part 3: Hot Links in Pierre's Messages
+
+`ChatMessage.tsx` renders assistant messages via `ReactMarkdown`. Standard `[text](url)` links render as `<a href>` which causes full page reloads. We need to intercept internal links and use wouter's `setLocation()` for SPA navigation.
+
+## Technical Approach
+
+### Files to Modify
+
+| File | Change |
+|---|---|
+| `client/src/pages/OnboardingQuiz.tsx` | Add 2 new screens, "Not sure" options, reframe food screen |
+| `shared/schema.ts` | Extend `OnboardingData` with `drinkPreferences`, `occasion`, and `not_sure` enum values |
+| `server/routes/user.ts` | Update Zod schema to accept new fields and "not_sure" values |
+| `server/services/sommelierContextBuilder.ts` | Add drink→palate mapping, occasion context |
+| `client/src/components/sommelier/ChatMessage.tsx` | Override ReactMarkdown `a` component for SPA navigation |
+| `client/src/components/sommelier/SommelierChatSheet.tsx` | Replace `WelcomeState` with welcome message when `pierre=welcome` |
+| `client/src/hooks/useSommelierChat.ts` | Accept optional initial message, expose `setMessages` or inject mechanism |
+
+### Implementation Details
+
+#### A. Quiz Enhancements (`OnboardingQuiz.tsx`)
+
+Extend the `QuizStep` type:
+```typescript
+type QuizStep = "knowledge" | "vibe" | "food" | "drinks" | "occasion";
+```
+
+Add `not_sure` to single-select option arrays. Add new `DRINK_OPTIONS` and `OCCASION_OPTIONS` arrays. The `StepHeader` reads `totalSteps` from the array length so the progress bar auto-updates.
+
+Extend `QuizAnswers`:
+```typescript
+interface QuizAnswers {
+  knowledgeLevel: string | null;
+  wineVibe: string | null;
+  foodPreferences: string[];
+  drinkPreferences: string[];
+  occasion: string | null;
+}
+```
+
+#### B. Schema Changes (`shared/schema.ts`)
+
+```typescript
+export interface OnboardingData {
+  knowledgeLevel: 'beginner' | 'casual' | 'enthusiast' | 'nerd' | 'not_sure';
+  wineVibe: 'bold' | 'light' | 'sweet' | 'adventurous' | 'not_sure';
+  foodPreferences: string[];
+  drinkPreferences: string[];
+  occasion: 'learning' | 'go_to_bottle' | 'impress' | 'date_night' | 'not_sure';
+  completedAt: string;
+}
+```
+
+#### C. Zod Validation (`server/routes/user.ts`)
+
+Update `onboardingSchema` to accept new fields:
+```typescript
+const onboardingSchema = z.object({
+  knowledgeLevel: z.enum(['beginner', 'casual', 'enthusiast', 'nerd', 'not_sure']),
+  wineVibe: z.enum(['bold', 'light', 'sweet', 'adventurous', 'not_sure']),
+  foodPreferences: z.array(z.string()).max(15),  // remove .min(1)
+  drinkPreferences: z.array(z.string()).max(10),
+  occasion: z.enum(['learning', 'go_to_bottle', 'impress', 'date_night', 'not_sure']),
+});
+```
+
+#### D. Drink-to-Palate Mapping (`sommelierContextBuilder.ts`)
+
+```typescript
+const drinkPalateMap: Record<string, string> = {
+  black_coffee: "tolerates bitterness — likely enjoys tannic reds",
+  iced_latte: "likes creamy, smooth textures — try oaked Chardonnay",
+  tea: "appreciates delicate flavors — lighter wines, Pinot Noir",
+  sparkling_water: "enjoys acidity and fizz — sparkling wines, Sauvignon Blanc",
+  apple_juice: "prefers sweetness — Moscato, off-dry Riesling",
+  lemonade: "likes tart + sweet balance — crisp whites, Vinho Verde",
+  cola: "sweet + bold — fruit-forward Zinfandel, Malbec",
+  kombucha: "open to funky/sour — natural wines, orange wines",
+};
+```
+
+Add to Pierre's context: `"Based on drink preferences (coffee, sparkling water): likely enjoys bitterness + acidity → try Barolo, Chablis"`
+
+#### E. Hot Links in Chat (`ChatMessage.tsx`)
+
+Add a custom `components` prop to `ReactMarkdown`:
+```tsx
+// In ChatMessage.tsx
+import { useLocation } from "wouter";
+
+const [, setLocation] = useLocation();
+
+<ReactMarkdown
+  remarkPlugins={[remarkGfm]}
+  components={{
+    a: ({ href, children }) => {
+      if (href?.startsWith("/")) {
+        return (
+          <button
+            onClick={() => {
+              onClose?.();  // close Pierre drawer
+              setLocation(href);
+            }}
+            className="text-purple-400 underline hover:text-purple-300 cursor-pointer"
+          >
+            {children}
+          </button>
+        );
+      }
+      return <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>;
+    },
+  }}
+>
+```
+
+**Important**: When a user taps an in-app link, Pierre's drawer should close first, then navigate. This prevents the drawer from floating over the destination page.
+
+Pass an `onClose` callback from `SommelierChatSheet` → `MessageList` → `ChatMessage`.
+
+#### F. Welcome Message Injection (`SommelierChatSheet.tsx` + `useSommelierChat.ts`)
+
+When Pierre opens via `?pierre=welcome`:
+
+1. `SommelierChatSheet` detects the URL param
+2. Instead of showing `WelcomeState`, it calls a `injectWelcomeMessage(onboardingData)` function
+3. This builds a markdown string from the user's quiz answers and injects it as a synthetic `ChatMessage` with `role: "assistant"` and a special `id: -2` (to distinguish from streamed messages)
+4. The message is **local-only** — not persisted to the database
+5. Once the user sends their first real message, the welcome message stays in the UI but the API call creates a new chat normally
+
+Build the welcome message client-side using a template function:
+```typescript
+function buildWelcomeMessage(data: OnboardingData): string {
+  // Personalized opening based on quiz answers
+  // Feature links with markdown [text](/route) format
+  // Recommendation based on occasion
+  // Closing prompt
+}
+```
+
+#### G. WelcomeState Replacement Logic
+
+In `SommelierChatSheet.tsx`, the current logic:
+```typescript
+const showWelcome = !isLoading && !isLoadingChat && messages.length === 0;
+```
+
+Change to: if `?pierre=welcome` is in the URL AND `messages.length === 0`, inject the welcome message instead of showing `WelcomeState`. The `WelcomeState` component still shows for returning users who open Pierre normally (no URL param, empty chat).
+
+## Acceptance Criteria
+
+### Quiz
+- [ ] Every single-select question has a "Not sure yet" option
+- [ ] Food screen reframed with new title/subtitle and 3 additional options
+- [ ] Food and drinks screens allow 0 selections (skip-friendly)
+- [ ] New "drinks" screen with 8 non-alcoholic options, multi-select grid
+- [ ] New "occasion" screen with 5 options + "Not sure yet", single-select
+- [ ] Progress bar shows 5 steps, back navigation works across all
+- [ ] All "Not sure" selections save correctly and don't break context builder
+
+### Pierre Welcome
+- [ ] After completing quiz, Pierre opens with a personalized first message (not generic WelcomeState)
+- [ ] Welcome message references at least one quiz answer specifically
+- [ ] Welcome message contains 3-4 hot links to app features
+- [ ] Hot links trigger SPA navigation (no full page reload)
+- [ ] Clicking a hot link closes the Pierre drawer, then navigates
+- [ ] Welcome message recommends a starting point based on occasion answer
+- [ ] If user selected "Not sure" for everything, welcome message is still warm and helpful
+
+### Hot Links (all Pierre messages, not just welcome)
+- [ ] Internal links (`/journeys`, `/tasting/new`, etc.) use wouter navigation
+- [ ] External links open in new tab
+- [ ] Links are visually styled (purple, underlined) consistent with chat theme
+
+### Backend
+- [ ] `OnboardingData` schema extended with `drinkPreferences`, `occasion`
+- [ ] Zod validation accepts new fields and "not_sure" values
+- [ ] Context builder includes drink-to-palate mapping in Pierre's system prompt
+- [ ] Context builder includes occasion for recommendation framing
+- [ ] Skip flow still works (saves `onboardingCompleted: true` with no data)
+
+## Edge Cases
+
+- **User picks "Not sure" for everything**: Welcome message should still be warm and orient them to the app. "No worries — that's literally what Cata is for. The best way to figure out what you like is to **[taste whatever you're drinking right now](/tasting/new)** — just snap the bottle and answer a few questions. I'll start learning your palate from there. You can also **[browse Learning Journeys](/journeys)** if you want a guided starting point, or **[host a group tasting](/home/group)** with friends."
+- **User skips onboarding entirely**: No welcome message. Regular `WelcomeState` shows.
+- **User closes Pierre immediately after it auto-opens**: Welcome message stays in local state. If they reopen Pierre later (without `?pierre=welcome`), they see the regular `WelcomeState` for a new chat. The welcome message was ephemeral.
+- **5 screens on mobile**: Keep each screen scrollable. The food/drinks grids (2-column) fit well on mobile. Single-select screens are already compact.
+- **Hot link to `/journeys` when no journeys exist**: The JourneyBrowser page handles empty state already. No special handling needed.
+
+## Dependencies
+
+- Existing `feat/onboarding-flow` branch (PR #14) — this plan builds on that work
+- No new dependencies needed
+
+## References
+
+- Current onboarding: `client/src/pages/OnboardingQuiz.tsx`
+- Chat message rendering: `client/src/components/sommelier/ChatMessage.tsx:35-38`
+- Chat hook (message state): `client/src/hooks/useSommelierChat.ts:26`
+- Welcome state component: `client/src/components/sommelier/SommelierChatSheet.tsx:22-87`
+- Pierre personality prompt: `prompts/sommelier_chat.txt`
+- Context builder: `server/services/sommelierContextBuilder.ts`
+- Onboarding API: `server/routes/user.ts`
+- Schema: `shared/schema.ts:726-731`
+- Existing learnings: `docs/solutions/best-practices/ai-chat-ux-patterns-SommelierChat-20260213.md`
+- State preservation patterns: `docs/solutions/ui-bugs/state-loss-accidental-dismiss-pierre-chat-20260215.md`

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 // Note: Removed problematic reorderSlidesForWineSimple function
 // Now using proven storage.batchUpdateSlidePositions instead
 import { registerMediaProxyRoutes } from './routes/media-proxy';
+import { registerUserRoutes } from './routes/user';
 import { registerDashboardRoutes } from './routes/dashboard';
 import { registerAuthRoutes } from './routes/auth';
 import { registerTastingsRoutes } from './routes/tastings';
@@ -2108,6 +2109,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Register media proxy routes
   registerMediaProxyRoutes(app);
+
+  // Register user routes (onboarding)
+  registerUserRoutes(app);
 
   console.log("✅ All routes registered successfully!");
   const httpServer = createServer(app);

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -251,7 +251,8 @@ export function registerAuthRoutes(app: Express): void {
           // Agent-native: include tasting level info for automated workflows
           tastingLevel: user.tastingLevel,
           tastingsCompleted: user.tastingsCompleted,
-          levelUpPromptEligible: user.levelUpPromptEligible
+          levelUpPromptEligible: user.levelUpPromptEligible,
+          onboardingCompleted: user.onboardingCompleted
         }
       });
     } catch (error) {

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -252,7 +252,8 @@ export function registerAuthRoutes(app: Express): void {
           tastingLevel: user.tastingLevel,
           tastingsCompleted: user.tastingsCompleted,
           levelUpPromptEligible: user.levelUpPromptEligible,
-          onboardingCompleted: user.onboardingCompleted
+          onboardingCompleted: user.onboardingCompleted,
+          onboardingData: user.onboardingData
         }
       });
     } catch (error) {

--- a/server/routes/sommelier-chat.ts
+++ b/server/routes/sommelier-chat.ts
@@ -42,6 +42,33 @@ export function registerSommelierChatRoutes(app: Express): void {
   });
 
   /**
+   * POST /api/sommelier-chat/welcome
+   * Persist a welcome message as a new chat (called after onboarding).
+   */
+  app.post("/api/sommelier-chat/welcome", requireAuth, async (req: Request, res: Response) => {
+    try {
+      const userId = req.session.userId!;
+      const { content } = req.body;
+
+      if (!content || typeof content !== "string") {
+        return res.status(400).json({ error: "Content is required" });
+      }
+
+      const chat = await storage.createSommelierChat({ userId, title: "Welcome to Cata", messageCount: 0 });
+      const message = await storage.createSommelierMessage({
+        chatId: chat.id,
+        role: "assistant",
+        content,
+      });
+
+      return res.json({ chatId: chat.id, message });
+    } catch (error) {
+      console.error("[SommelierChat] Welcome message error:", error);
+      return res.status(500).json({ error: "Failed to save welcome message" });
+    }
+  });
+
+  /**
    * GET /api/sommelier-chat/list
    * Get all user chats with messages (newest first)
    */

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -7,9 +7,11 @@ import { z } from "zod";
 import { validationError, internalError } from "../lib/api-error";
 
 const onboardingSchema = z.object({
-  knowledgeLevel: z.enum(['beginner', 'casual', 'enthusiast', 'nerd']),
-  wineVibe: z.enum(['bold', 'light', 'sweet', 'adventurous']),
-  foodPreferences: z.array(z.string()).min(1).max(10),
+  knowledgeLevel: z.enum(['beginner', 'casual', 'enthusiast', 'nerd', 'not_sure']),
+  wineVibe: z.enum(['bold', 'light', 'sweet', 'adventurous', 'not_sure']),
+  foodPreferences: z.array(z.string()).max(15),
+  drinkPreferences: z.array(z.string()).max(10),
+  occasion: z.enum(['learning', 'go_to_bottle', 'impress', 'date_night', 'not_sure']),
 });
 
 // Also accept skip requests (no data)
@@ -49,12 +51,14 @@ export function registerUserRoutes(app: Express): void {
         return validationError(res, "Invalid onboarding data");
       }
 
-      const { knowledgeLevel, wineVibe, foodPreferences } = parsed.data;
+      const { knowledgeLevel, wineVibe, foodPreferences, drinkPreferences, occasion } = parsed.data;
 
       const onboardingData: OnboardingData = {
         knowledgeLevel,
         wineVibe,
         foodPreferences,
+        drinkPreferences,
+        occasion,
         completedAt: new Date().toISOString(),
       };
 

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -1,0 +1,77 @@
+import type { Express, Request, Response } from "express";
+import { db } from "../db";
+import { users, type OnboardingData } from "@shared/schema";
+import { eq } from "drizzle-orm";
+import { requireAuth } from "./auth";
+import { z } from "zod";
+import { validationError, internalError } from "../lib/api-error";
+
+const onboardingSchema = z.object({
+  knowledgeLevel: z.enum(['beginner', 'casual', 'enthusiast', 'nerd']),
+  wineVibe: z.enum(['bold', 'light', 'sweet', 'adventurous']),
+  foodPreferences: z.array(z.string()).min(1).max(10),
+});
+
+// Also accept skip requests (no data)
+const skipOnboardingSchema = z.object({
+  skip: z.literal(true),
+});
+
+const tastingLevelMap: Record<string, string> = {
+  beginner: 'intro',
+  casual: 'intro',
+  enthusiast: 'intermediate',
+  nerd: 'advanced',
+};
+
+export function registerUserRoutes(app: Express): void {
+  // Save onboarding quiz answers (or skip)
+  app.post("/api/user/onboarding", requireAuth, async (req: Request, res: Response) => {
+    const userId = req.session.userId!;
+
+    try {
+      // Check if skip request
+      const skipParsed = skipOnboardingSchema.safeParse(req.body);
+      if (skipParsed.success) {
+        await db.update(users).set({
+          onboardingCompleted: true,
+        }).where(eq(users.id, userId));
+
+        const updatedUser = await db.query.users.findFirst({
+          where: eq(users.id, userId),
+        });
+        return res.json({ user: updatedUser });
+      }
+
+      // Validate quiz answers
+      const parsed = onboardingSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return validationError(res, "Invalid onboarding data");
+      }
+
+      const { knowledgeLevel, wineVibe, foodPreferences } = parsed.data;
+
+      const onboardingData: OnboardingData = {
+        knowledgeLevel,
+        wineVibe,
+        foodPreferences,
+        completedAt: new Date().toISOString(),
+      };
+
+      await db.update(users).set({
+        onboardingCompleted: true,
+        onboardingData,
+        tastingLevel: tastingLevelMap[knowledgeLevel] || 'intro',
+      }).where(eq(users.id, userId));
+
+      const updatedUser = await db.query.users.findFirst({
+        where: eq(users.id, userId),
+      });
+
+      return res.json({ user: updatedUser });
+    } catch (error) {
+      console.error("[User] Onboarding save error:", error);
+      return internalError(res, "Failed to save onboarding data");
+    }
+  });
+}

--- a/server/services/sommelierContextBuilder.ts
+++ b/server/services/sommelierContextBuilder.ts
@@ -4,6 +4,7 @@
  */
 
 import { storage } from "../storage";
+import type { OnboardingData } from "@shared/schema";
 import fs from "fs/promises";
 import path from "path";
 
@@ -54,6 +55,28 @@ async function buildUserContext(email: string): Promise<string> {
     // Basic info
     lines.push(`Level: ${user.tastingLevel || "intro"} (${user.tastingsCompleted || 0} tastings)`);
     if (user.wineArchetype) lines.push(`Wine Archetype: ${user.wineArchetype}`);
+
+    // Onboarding profile (if completed)
+    if (user.onboardingData) {
+      const ob = user.onboardingData as OnboardingData;
+      const vibeMap: Record<string, string> = {
+        bold: "bold, full-bodied wines",
+        light: "light, crisp wines",
+        sweet: "sweet, fruit-forward wines",
+        adventurous: "trying new and unusual wines",
+      };
+      const knowledgeMap: Record<string, string> = {
+        beginner: "brand new to wine",
+        casual: "drinks wine casually, knows what they like",
+        enthusiast: "actively learning about wine",
+        nerd: "serious wine knowledge",
+      };
+      if (ob.knowledgeLevel) lines.push(`Self-described: ${knowledgeMap[ob.knowledgeLevel] || ob.knowledgeLevel}`);
+      if (ob.wineVibe) lines.push(`Style preference: ${vibeMap[ob.wineVibe] || ob.wineVibe}`);
+      if (ob.foodPreferences?.length > 0) {
+        lines.push(`Favorite foods: ${ob.foodPreferences.join(", ")}`);
+      }
+    }
 
     // Favorites from conversation starters
     if (starters) {

--- a/server/services/sommelierContextBuilder.ts
+++ b/server/services/sommelierContextBuilder.ts
@@ -71,10 +71,41 @@ async function buildUserContext(email: string): Promise<string> {
         enthusiast: "actively learning about wine",
         nerd: "serious wine knowledge",
       };
-      if (ob.knowledgeLevel) lines.push(`Self-described: ${knowledgeMap[ob.knowledgeLevel] || ob.knowledgeLevel}`);
-      if (ob.wineVibe) lines.push(`Style preference: ${vibeMap[ob.wineVibe] || ob.wineVibe}`);
+      const drinkPalateMap: Record<string, string> = {
+        black_coffee: "tolerates bitterness — tannic reds",
+        iced_latte: "likes creamy, smooth textures — oaked Chardonnay",
+        tea: "appreciates delicate flavors — lighter wines, Pinot Noir",
+        sparkling_water: "enjoys acidity and fizz — sparkling wines, Sauvignon Blanc",
+        apple_juice: "prefers sweetness — Moscato, off-dry Riesling",
+        lemonade: "likes tart + sweet balance — crisp whites, Vinho Verde",
+        cola: "sweet + bold — fruit-forward Zinfandel, Malbec",
+        kombucha: "open to funky/sour — natural wines, orange wines",
+      };
+      const occasionMap: Record<string, string> = {
+        learning: "here to learn about wine for fun",
+        go_to_bottle: "looking for a reliable everyday bottle",
+        impress: "wants to sound knowledgeable at restaurants and dinners",
+        date_night: "looking for wines for special occasions",
+      };
+      if (ob.knowledgeLevel && ob.knowledgeLevel !== "not_sure") {
+        lines.push(`Self-described: ${knowledgeMap[ob.knowledgeLevel] || ob.knowledgeLevel}`);
+      }
+      if (ob.wineVibe && ob.wineVibe !== "not_sure") {
+        lines.push(`Style preference: ${vibeMap[ob.wineVibe] || ob.wineVibe}`);
+      }
       if (ob.foodPreferences?.length > 0) {
         lines.push(`Favorite foods: ${ob.foodPreferences.join(", ")}`);
+      }
+      if (ob.drinkPreferences?.length > 0) {
+        const palateSignals = ob.drinkPreferences
+          .map((d) => drinkPalateMap[d])
+          .filter(Boolean);
+        if (palateSignals.length > 0) {
+          lines.push(`Palate signals from non-wine drinks: ${palateSignals.join("; ")}`);
+        }
+      }
+      if (ob.occasion && ob.occasion !== "not_sure") {
+        lines.push(`Goal: ${occasionMap[ob.occasion] || ob.occasion}`);
       }
     }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -653,7 +653,10 @@ export const users = pgTable("users", {
   tastingsCompleted: integer("tastings_completed").default(0).notNull(),
   levelUpPromptEligible: boolean("level_up_prompt_eligible").default(false).notNull(),
   // Phase 1: Wine archetype for identity (e.g., "Bold Explorer", "Elegant Traditionalist")
-  wineArchetype: varchar("wine_archetype", { length: 100 })
+  wineArchetype: varchar("wine_archetype", { length: 100 }),
+  // Onboarding quiz
+  onboardingCompleted: boolean("onboarding_completed").default(false).notNull(),
+  onboardingData: jsonb("onboarding_data"), // OnboardingData blob
 }, (table) => ({
   emailIdx: index("idx_users_email").on(table.email)
 }));
@@ -718,6 +721,14 @@ export const insertTastingSchema = createInsertSchema(tastings, {
   id: true,
   tastedAt: true
 });
+
+// Onboarding quiz answers
+export interface OnboardingData {
+  knowledgeLevel: 'beginner' | 'casual' | 'enthusiast' | 'nerd';
+  wineVibe: 'bold' | 'light' | 'sweet' | 'adventurous';
+  foodPreferences: string[];
+  completedAt: string;
+}
 
 // Types for solo tasting
 export type User = typeof users.$inferSelect;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -724,9 +724,11 @@ export const insertTastingSchema = createInsertSchema(tastings, {
 
 // Onboarding quiz answers
 export interface OnboardingData {
-  knowledgeLevel: 'beginner' | 'casual' | 'enthusiast' | 'nerd';
-  wineVibe: 'bold' | 'light' | 'sweet' | 'adventurous';
+  knowledgeLevel: 'beginner' | 'casual' | 'enthusiast' | 'nerd' | 'not_sure';
+  wineVibe: 'bold' | 'light' | 'sweet' | 'adventurous' | 'not_sure';
   foodPreferences: string[];
+  drinkPreferences: string[];
+  occasion: 'learning' | 'go_to_bottle' | 'impress' | 'date_night' | 'not_sure';
   completedAt: string;
 }
 


### PR DESCRIPTION
## Summary

- **Onboarding quiz flow**: New 5-step onboarding (knowledge level, vibe, food preferences, drink preferences, occasion) with auto-advancing selection and swipe navigation
- **Pierre welcome tutorial**: After completing onboarding, Pierre (AI sommelier) automatically opens and delivers a personalized welcome message based on user preferences
- **Unified login flow**: Login now routes new/unboarded users to `/onboarding` instead of `/home`
- **Stale cache fix**: Clears TanStack Query auth cache on login to prevent previous user's data from leaking

## Key Changes

### Login flow (`Login.tsx`)
- New users (404 from dashboard check) → `/onboarding` instead of `/home`
- Existing users with incomplete onboarding → `/onboarding`
- Added `queryClient.removeQueries()` after login to clear stale auth cache

### Onboarding quiz (`OnboardingQuiz.tsx`)
- 5-step quiz with knowledge, vibe, food, drinks, occasion
- Auto-advance on single-select, manual next on multi-select
- Skip option always available
- Saves preferences via `POST /api/user/onboarding`
- Uses `setQueryData` to immediately update `onboardingCompleted` in cache (prevents redirect bounce)
- Sets `sessionStorage("pierre_welcome")` flag for Pierre handoff

### Pierre welcome (`SommelierFAB.tsx` + `SommelierChatSheet.tsx`)
- FAB checks sessionStorage for `pierre_welcome` flag
- Opens chat immediately (no timeout) with `isWelcome` prop
- Chat sheet sends `POST /api/sommelier-chat/welcome` to persist welcome message
- Welcome message personalized with user's onboarding preferences

### Server (`routes/user.ts` + `routes/sommelier-chat.ts`)
- `POST /api/user/onboarding` — saves onboarding preferences to user record
- `POST /api/sommelier-chat/welcome` — persists Pierre's welcome message in chat history

## Bugs Fixed

1. **Stale TanStack Query cache after login** — Previous user's `onboardingCompleted: true` was cached, causing new users to skip onboarding entirely
2. **Pierre welcome never firing** — URL params (`?pierre=welcome`) were stripped during redirect bounces; switched to sessionStorage
3. **setTimeout cancelled by redirect** — Redirect ping-pong between HomeV2 and OnboardingQuiz killed the Pierre open timer; removed timeout entirely
4. **Redirect bounce after onboarding** — HomeV2 saw stale `onboardingCompleted: false` and bounced user back to onboarding; fixed with `setQueryData` for immediate cache update

## Test Plan

- [ ] New user signs in → lands on `/onboarding` (not `/home`)
- [ ] User completes all 5 onboarding questions without being kicked out
- [ ] After final question, Pierre FAB opens automatically with personalized welcome
- [ ] "Skip for now" also triggers Pierre welcome
- [ ] Switching between users (logout → login) doesn't leak previous user's data
- [ ] Existing onboarded users go straight to `/home`

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)