### PR TITLE
feat: Learning Journey Enhancement — three-beat questions, budget/splurge wines, nearby shops

### DIFF
--- a/client/src/components/NearbyWineShops.tsx
+++ b/client/src/components/NearbyWineShops.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { motion, AnimatePresence } from "framer-motion";
+import { MapPin, Store, Star, Loader2, Navigation, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useGeolocation } from "@/hooks/useGeolocation";
+
+interface Shop {
+  id: string;
+  name: string;
+  address: string;
+  rating: number | null;
+  ratingCount: number | null;
+  lat: number;
+  lng: number;
+}
+
+export function NearbyWineShops() {
+  const { position, error: geoError, loading: geoLoading, requestLocation } = useGeolocation();
+  const [hasRequested, setHasRequested] = useState(false);
+
+  const { data, isLoading: shopsLoading, error: shopsError } = useQuery<{ shops: Shop[] }>({
+    queryKey: ["nearby-wine-shops", position?.latitude, position?.longitude],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/wine-shops/nearby?latitude=${position!.latitude}&longitude=${position!.longitude}&radius=5000`
+      );
+      if (!response.ok) throw new Error("Failed to fetch shops");
+      return response.json();
+    },
+    enabled: !!position,
+    staleTime: 1000 * 60 * 30 // 30 minutes
+  });
+
+  const handleFindShops = () => {
+    setHasRequested(true);
+    requestLocation();
+  };
+
+  const openInMaps = (shop: Shop) => {
+    const url = `https://maps.google.com/?q=${shop.lat},${shop.lng}`;
+    window.open(url, "_blank");
+  };
+
+  // Initial state — show button
+  if (!hasRequested) {
+    return (
+      <div className="mt-4">
+        <Button
+          onClick={handleFindShops}
+          variant="outline"
+          className="w-full border-purple-500/30 text-purple-300 hover:bg-purple-500/10"
+        >
+          <MapPin className="w-4 h-4 mr-2" />
+          Find wine shops near you
+        </Button>
+        <p className="text-xs text-purple-300/50 text-center mt-1.5">
+          Your location is not stored
+        </p>
+      </div>
+    );
+  }
+
+  // Loading geolocation
+  if (geoLoading) {
+    return (
+      <div className="mt-4 flex items-center justify-center gap-2 py-4 text-purple-300/70 text-sm">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        Getting your location...
+      </div>
+    );
+  }
+
+  // Geolocation error
+  if (geoError) {
+    return (
+      <div className="mt-4 bg-white/5 rounded-lg p-3 border border-white/10">
+        <div className="flex items-start gap-2">
+          <AlertCircle className="w-4 h-4 text-amber-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm text-white/80">{geoError}</p>
+            <Button
+              onClick={handleFindShops}
+              variant="ghost"
+              size="sm"
+              className="text-purple-300 hover:text-white mt-2 h-7 px-2"
+            >
+              Try again
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Loading shops
+  if (shopsLoading) {
+    return (
+      <div className="mt-4 flex items-center justify-center gap-2 py-4 text-purple-300/70 text-sm">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        Finding wine shops nearby...
+      </div>
+    );
+  }
+
+  // API error
+  if (shopsError) {
+    return (
+      <div className="mt-4 bg-white/5 rounded-lg p-3 border border-white/10">
+        <p className="text-sm text-white/70">Couldn't find wine shops right now. Try again later.</p>
+      </div>
+    );
+  }
+
+  const shops = data?.shops || [];
+
+  // No results
+  if (shops.length === 0) {
+    return (
+      <div className="mt-4 bg-white/5 rounded-lg p-3 border border-white/10 text-center">
+        <Store className="w-8 h-8 text-purple-400/40 mx-auto mb-2" />
+        <p className="text-sm text-white/70">No wine shops found nearby.</p>
+        <p className="text-xs text-purple-300/50 mt-1">Try a different area or check online retailers.</p>
+      </div>
+    );
+  }
+
+  // Show shops
+  return (
+    <div className="mt-4">
+      <h4 className="text-sm font-medium text-purple-300 mb-2 flex items-center gap-1.5">
+        <MapPin className="w-4 h-4" />
+        Wine shops near you
+      </h4>
+      <div className="space-y-2">
+        <AnimatePresence>
+          {shops.map((shop, i) => (
+            <motion.button
+              key={shop.id}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.05 }}
+              onClick={() => openInMaps(shop)}
+              className="w-full bg-white/5 hover:bg-white/10 rounded-lg p-3 border border-white/10 text-left transition-colors"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-white truncate">{shop.name}</p>
+                  <p className="text-xs text-purple-300/60 truncate mt-0.5">{shop.address}</p>
+                </div>
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  {shop.rating && (
+                    <div className="flex items-center gap-0.5 text-xs text-amber-400">
+                      <Star className="w-3 h-3 fill-current" />
+                      <span>{shop.rating}</span>
+                    </div>
+                  )}
+                  <Navigation className="w-3.5 h-3.5 text-purple-400 ml-1" />
+                </div>
+              </div>
+            </motion.button>
+          ))}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/WineOptionCard.tsx
+++ b/client/src/components/WineOptionCard.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { Wine, DollarSign, MessageCircle, Store } from "lucide-react";
+import { Wine, DollarSign, MessageCircle, Store, Tag, ArrowRightLeft } from "lucide-react";
 import type { WineOption } from "@shared/schema";
 
 interface WineOptionCardProps {
@@ -8,26 +8,23 @@ interface WineOptionCardProps {
   isSelected?: boolean;
 }
 
-const levelColors = {
-  entry: {
+const levelStyles = {
+  budget: {
     gradient: "from-green-500 to-emerald-600",
     badge: "bg-green-500/20 text-green-400",
-    label: "Entry Level"
+    label: "Budget",
+    sublabel: "Under $25"
   },
-  mid: {
-    gradient: "from-blue-500 to-purple-600",
-    badge: "bg-blue-500/20 text-blue-400",
-    label: "Mid-Range"
-  },
-  premium: {
+  splurge: {
     gradient: "from-amber-500 to-orange-600",
     badge: "bg-amber-500/20 text-amber-400",
-    label: "Premium"
+    label: "Splurge",
+    sublabel: "Worth it"
   }
 };
 
 export function WineOptionCard({ option, onSelect, isSelected }: WineOptionCardProps) {
-  const levelStyle = levelColors[option.level];
+  const style = levelStyles[option.level];
 
   return (
     <motion.div
@@ -41,20 +38,40 @@ export function WineOptionCard({ option, onSelect, isSelected }: WineOptionCardP
       onClick={onSelect}
     >
       {/* Level badge */}
-      <div className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium ${levelStyle.badge} mb-3`}>
-        <DollarSign className="w-3 h-3" />
-        {levelStyle.label}
+      <div className="flex items-center gap-2 mb-3">
+        <div className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium ${style.badge}`}>
+          <DollarSign className="w-3 h-3" />
+          {style.label}
+        </div>
+        {option.level === 'budget' && (
+          <span className="text-xs text-green-400/70">{style.sublabel}</span>
+        )}
       </div>
 
       {/* Description */}
       <h3 className="text-white font-medium text-lg mb-2">{option.description}</h3>
 
-      {/* Price range */}
-      <div className="flex items-center gap-2 text-white/70 text-sm mb-3">
-        <span className="font-mono">
-          ${option.priceRange.min} - ${option.priceRange.max}
-        </span>
-      </div>
+      {/* Price range — only shown for budget */}
+      {option.priceRange && (
+        <div className="flex items-center gap-2 text-white/70 text-sm mb-3">
+          <span className="font-mono">
+            ${option.priceRange.min} - ${option.priceRange.max}
+          </span>
+        </div>
+      )}
+
+      {/* Label tips */}
+      {option.labelTips && (
+        <div className="bg-white/5 rounded-lg p-3 mb-3">
+          <div className="flex items-start gap-2">
+            <Tag className="w-4 h-4 text-blue-400 flex-shrink-0 mt-0.5" />
+            <div>
+              <p className="text-xs text-white/50 mb-1">Look for on the label:</p>
+              <p className="text-sm text-white/90">{option.labelTips}</p>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* What to ask for */}
       <div className="bg-white/5 rounded-lg p-3 mb-3">
@@ -66,6 +83,19 @@ export function WineOptionCard({ option, onSelect, isSelected }: WineOptionCardP
           </div>
         </div>
       </div>
+
+      {/* Substitutes */}
+      {option.substitutes && option.substitutes.length > 0 && (
+        <div className="flex items-start gap-2 mb-3">
+          <ArrowRightLeft className="w-4 h-4 text-white/40 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-xs text-white/50 mb-1">Also works:</p>
+            <p className="text-sm text-white/70">
+              {option.substitutes.join(", ")}
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Example producers */}
       {option.exampleProducers && option.exampleProducers.length > 0 && (
@@ -80,7 +110,7 @@ export function WineOptionCard({ option, onSelect, isSelected }: WineOptionCardP
         </div>
       )}
 
-      {/* Why this wine (if available) */}
+      {/* Why this wine */}
       {option.whyThisWine && (
         <p className="text-xs text-white/50 mt-3 italic">
           {option.whyThisWine}
@@ -103,14 +133,17 @@ export function WineOptionCard({ option, onSelect, isSelected }: WineOptionCardP
 
 interface WineOptionsListProps {
   options: WineOption[];
-  selectedLevel?: 'entry' | 'mid' | 'premium';
-  onSelectOption?: (level: 'entry' | 'mid' | 'premium') => void;
+  selectedLevel?: 'budget' | 'splurge';
+  onSelectOption?: (level: 'budget' | 'splurge') => void;
 }
 
 export function WineOptionsList({ options, selectedLevel, onSelectOption }: WineOptionsListProps) {
   if (!options || options.length === 0) {
     return null;
   }
+
+  // Sort: budget first, splurge second
+  const sorted = [...options].sort((a, b) => (a.level === 'budget' ? -1 : 1));
 
   return (
     <div className="space-y-3">
@@ -119,10 +152,10 @@ export function WineOptionsList({ options, selectedLevel, onSelectOption }: Wine
         Wine Options
       </h3>
       <p className="text-white/60 text-sm">
-        Choose a price point that works for you - any option will work for this chapter.
+        Pick whichever fits your mood — same lesson either way.
       </p>
-      <div className="grid gap-3">
-        {options.map((option) => (
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {sorted.map((option) => (
           <WineOptionCard
             key={option.level}
             option={option}

--- a/client/src/hooks/useGeolocation.ts
+++ b/client/src/hooks/useGeolocation.ts
@@ -1,0 +1,62 @@
+import { useState, useCallback } from "react";
+
+interface GeolocationPosition {
+  latitude: number;
+  longitude: number;
+}
+
+interface UseGeolocationReturn {
+  position: GeolocationPosition | null;
+  error: string | null;
+  loading: boolean;
+  requestLocation: () => void;
+}
+
+export function useGeolocation(): UseGeolocationReturn {
+  const [position, setPosition] = useState<GeolocationPosition | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const requestLocation = useCallback(() => {
+    if (!navigator.geolocation) {
+      setError("Your browser doesn't support location services.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setPosition({
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude
+        });
+        setLoading(false);
+      },
+      (err) => {
+        switch (err.code) {
+          case err.PERMISSION_DENIED:
+            setError("Location access denied. Enable location in your browser or device settings to find nearby shops.");
+            break;
+          case err.POSITION_UNAVAILABLE:
+            setError("Location unavailable. Try again in a moment.");
+            break;
+          case err.TIMEOUT:
+            setError("Location request timed out. Try again.");
+            break;
+          default:
+            setError("Could not get your location.");
+        }
+        setLoading(false);
+      },
+      {
+        enableHighAccuracy: false,
+        timeout: 10000,
+        maximumAge: 5 * 60 * 1000 // 5-minute cache
+      }
+    );
+  }, []);
+
+  return { position, error, loading, requestLocation };
+}

--- a/client/src/pages/JourneyDetail.tsx
+++ b/client/src/pages/JourneyDetail.tsx
@@ -25,6 +25,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
 import { WineOptionsList } from "@/components/WineOptionCard";
+import { NearbyWineShops } from "@/components/NearbyWineShops";
 import type { WineOption } from "@shared/schema";
 
 interface Chapter {
@@ -495,6 +496,8 @@ export default function JourneyDetail() {
                             selectedLevel={selectedWineLevel}
                             onSelectOption={setSelectedWineLevel}
                           />
+                          {/* Nearby wine shops */}
+                          <NearbyWineShops />
                         </div>
                       )}
 

--- a/client/src/pages/JourneyDetail.tsx
+++ b/client/src/pages/JourneyDetail.tsx
@@ -90,6 +90,7 @@ export default function JourneyDetail() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const [showShoppingList, setShowShoppingList] = useState(false);
+  const [selectedWineLevel, setSelectedWineLevel] = useState<'budget' | 'splurge' | undefined>();
 
   const journeyId = parseInt(id || "0");
 
@@ -149,8 +150,15 @@ export default function JourneyDetail() {
   };
 
   const handleStartChapter = (chapter: Chapter) => {
-    // Navigate to solo tasting with journey context
-    setLocation(`/solo/new?journeyId=${journeyId}&chapterId=${chapter.id}`);
+    // Navigate to solo tasting with journey context + selected wine level
+    const params = new URLSearchParams({
+      journeyId: String(journeyId),
+      chapterId: String(chapter.id)
+    });
+    if (selectedWineLevel) {
+      params.set('wineLevel', selectedWineLevel);
+    }
+    setLocation(`/solo/new?${params.toString()}`);
   };
 
   if (isLoading) {
@@ -479,10 +487,14 @@ export default function JourneyDetail() {
                         </div>
                       )}
 
-                      {/* Wine Options - Multiple price points (Sprint 5) */}
+                      {/* Wine Options - Budget / Splurge */}
                       {isCurrent && chapter.wineOptions && chapter.wineOptions.length > 0 && (
                         <div className="mb-3">
-                          <WineOptionsList options={chapter.wineOptions} />
+                          <WineOptionsList
+                            options={chapter.wineOptions}
+                            selectedLevel={selectedWineLevel}
+                            onSelectOption={setSelectedWineLevel}
+                          />
                         </div>
                       )}
 

--- a/client/src/pages/SoloTastingNew.tsx
+++ b/client/src/pages/SoloTastingNew.tsx
@@ -21,8 +21,12 @@ import {
   GraduationCap,
   ChevronRight,
   Sparkles,
-  ImagePlus
+  ImagePlus,
+  Tag,
+  ArrowRightLeft,
+  Store
 } from "lucide-react";
+import type { WineOption } from "@shared/schema";
 
 interface WineInfo {
   wineName: string;
@@ -51,6 +55,7 @@ interface Chapter {
   priceRange: { min: number; max: number; currency?: string } | null;
   alternatives: Array<{ name: string }> | null;
   askFor: string | null;
+  wineOptions: WineOption[] | null;
 }
 
 interface Journey {
@@ -75,6 +80,7 @@ export default function SoloTastingNew({ returnPath = "/solo" }: SoloTastingNewP
   const params = new URLSearchParams(search);
   const journeyId = params.get("journeyId");
   const chapterId = params.get("chapterId");
+  const wineLevel = params.get("wineLevel") as 'budget' | 'splurge' | null;
 
   const [view, setView] = useState<ViewState>('wine-entry');
   const [isScanning, setIsScanning] = useState(false);
@@ -423,8 +429,78 @@ export default function SoloTastingNew({ returnPath = "/solo" }: SoloTastingNewP
             </div>
           )}
 
-          {/* Shopping Guide */}
-          {chapter && (chapter.shoppingTips || chapter.askFor || chapter.priceRange) && (
+          {/* Shopping Guide — selected wine option */}
+          {chapter && wineLevel && chapter.wineOptions && (() => {
+            const selectedOption = chapter.wineOptions.find(o => o.level === wineLevel);
+            if (!selectedOption) return null;
+            return (
+              <div className="bg-gradient-to-br from-purple-900/30 to-pink-900/20 rounded-xl p-4 mb-6 border border-purple-500/20">
+                <div className="flex items-center justify-between mb-3">
+                  <div className="flex items-center gap-2">
+                    <ShoppingBag className="w-5 h-5 text-purple-400" />
+                    <span className="text-sm font-medium text-purple-300">Shopping Guide</span>
+                  </div>
+                  <span className={`text-xs px-2 py-0.5 rounded-full ${
+                    wineLevel === 'budget' ? 'bg-green-500/20 text-green-400' : 'bg-amber-500/20 text-amber-400'
+                  }`}>
+                    {wineLevel === 'budget' ? 'Budget' : 'Splurge'}
+                  </span>
+                </div>
+
+                <h4 className="text-white font-medium mb-2">{selectedOption.description}</h4>
+
+                {selectedOption.priceRange && (
+                  <div className="flex items-center gap-1 text-sm text-green-400/80 mb-3">
+                    <DollarSign className="w-4 h-4" />
+                    ${selectedOption.priceRange.min} – ${selectedOption.priceRange.max}
+                  </div>
+                )}
+
+                <div className="space-y-2">
+                  <div className="flex items-start gap-2">
+                    <MessageCircle className="w-4 h-4 text-purple-400 flex-shrink-0 mt-0.5" />
+                    <div>
+                      <p className="text-xs text-purple-300/70 mb-0.5">Ask for:</p>
+                      <p className="text-sm text-white">{selectedOption.askFor}</p>
+                    </div>
+                  </div>
+
+                  {selectedOption.labelTips && (
+                    <div className="flex items-start gap-2">
+                      <Tag className="w-4 h-4 text-blue-400 flex-shrink-0 mt-0.5" />
+                      <div>
+                        <p className="text-xs text-purple-300/70 mb-0.5">Look for on the label:</p>
+                        <p className="text-sm text-white/90">{selectedOption.labelTips}</p>
+                      </div>
+                    </div>
+                  )}
+
+                  {selectedOption.substitutes && selectedOption.substitutes.length > 0 && (
+                    <div className="flex items-start gap-2">
+                      <ArrowRightLeft className="w-4 h-4 text-white/40 flex-shrink-0 mt-0.5" />
+                      <div>
+                        <p className="text-xs text-purple-300/70 mb-0.5">Also works:</p>
+                        <p className="text-sm text-white/70">{selectedOption.substitutes.join(', ')}</p>
+                      </div>
+                    </div>
+                  )}
+
+                  {selectedOption.exampleProducers && selectedOption.exampleProducers.length > 0 && (
+                    <div className="flex items-start gap-2">
+                      <Store className="w-4 h-4 text-white/40 flex-shrink-0 mt-0.5" />
+                      <div>
+                        <p className="text-xs text-purple-300/70 mb-0.5">Examples:</p>
+                        <p className="text-sm text-white/70">{selectedOption.exampleProducers.join(', ')}</p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })()}
+
+          {/* Fallback shopping guide — when no wine option selected */}
+          {chapter && !wineLevel && (chapter.shoppingTips || chapter.askFor || chapter.priceRange) && (
             <div className="bg-gradient-to-br from-purple-900/30 to-pink-900/20 rounded-xl p-4 mb-6 border border-purple-500/20">
               <div className="flex items-center gap-2 mb-3">
                 <ShoppingBag className="w-5 h-5 text-purple-400" />

--- a/client/src/pages/SoloTastingSession.tsx
+++ b/client/src/pages/SoloTastingSession.tsx
@@ -39,10 +39,10 @@ interface ChapterContext {
   learningObjectives: string[];
 }
 
-// AI-generated question format from Sprint 5 - 5 core components
+// AI-generated question format — 6 core components with three-beat loop
 interface AIQuestion {
   id: string;
-  category: 'fruit' | 'secondary' | 'tertiary' | 'body' | 'acidity' | 'overall';
+  category: 'fruit' | 'secondary' | 'tertiary' | 'body' | 'acidity' | 'tannins' | 'overall';
   questionType: 'multiple_choice' | 'scale' | 'text';
   title: string;
   description?: string;
@@ -52,6 +52,9 @@ interface AIQuestion {
   scaleMax?: number;
   scaleLabels?: [string, string];
   wineContext?: string;
+  beatType?: 'notice' | 'rate';
+  educationalNote?: string;
+  preferenceDirection?: 'more' | 'less';
 }
 
 interface SoloTastingSessionProps {
@@ -62,10 +65,10 @@ interface SoloTastingSessionProps {
   aiQuestions?: AIQuestion[];
 }
 
-// Question definition type - supports both legacy and 5 core components
+// Question definition type - supports both legacy and 6 core components with three-beat loop
 interface TastingQuestion {
   id: string;
-  section: 'visual' | 'fruit' | 'secondary' | 'tertiary' | 'body' | 'acidity' | 'overall' | 'aroma' | 'taste' | 'structure' | 'chapter';
+  section: 'visual' | 'fruit' | 'secondary' | 'tertiary' | 'body' | 'acidity' | 'tannins' | 'overall' | 'aroma' | 'taste' | 'structure' | 'chapter';
   type: 'scale' | 'multiple_choice' | 'text' | 'boolean';
   config: {
     title: string;
@@ -81,153 +84,215 @@ interface TastingQuestion {
     placeholder?: string;
     rows?: number;
   };
+  // Three-beat loop metadata
+  beatType?: 'notice' | 'rate';
+  educationalNote?: string;
+  preferenceDirection?: 'more' | 'less';
 }
 
-// Preference-focused tasting questions (10 questions total)
-// Goal: Learn what the user likes, not test their wine knowledge
+// Three-beat tasting questions — notice+rate pairs per trait
+// Used as fallback when AI questions aren't available
 const TASTING_QUESTIONS: TastingQuestion[] = [
-  // AROMA SECTION (2 questions) - What smells do you notice/enjoy?
+  // --- FRUIT (notice + rate) ---
   {
-    id: 'aroma_notes',
-    section: 'aroma',
+    id: 'fruit-notice',
+    section: 'fruit',
     type: 'multiple_choice',
+    beatType: 'notice',
+    educationalNote: 'Wine gets its fruit flavors from the grape itself and fermentation. Red wines often show berry and cherry notes, while whites lean toward citrus and stone fruit.',
     config: {
-      title: 'What aromas do you notice?',
-      description: 'Swirl the glass and take a sniff. Select all that apply.',
+      title: 'What fruit flavors jump out at you?',
+      description: 'Swirl the glass gently and take a sip. Don\'t overthink it — what\'s the first thing that comes to mind?',
       options: [
-        { id: 'citrus', text: 'Citrus & Fresh Fruit', value: 'citrus' },
-        { id: 'tropical', text: 'Tropical & Stone Fruit', value: 'tropical' },
-        { id: 'berry', text: 'Berries & Dark Fruit', value: 'berry' },
-        { id: 'floral', text: 'Floral & Herbal', value: 'floral' },
-        { id: 'oak', text: 'Oak, Vanilla & Spice', value: 'oak' },
-        { id: 'earth', text: 'Earthy & Mineral', value: 'earth' }
+        { id: 'red-berries', text: 'Red berries (cherry, raspberry, strawberry)', value: 'red-berries' },
+        { id: 'dark-berries', text: 'Dark berries (blackberry, blueberry, plum)', value: 'dark-berries' },
+        { id: 'citrus', text: 'Citrus (lemon, lime, grapefruit)', value: 'citrus' },
+        { id: 'stone-fruit', text: 'Stone fruit (peach, apricot, nectarine)', value: 'stone-fruit' },
+        { id: 'tropical', text: 'Tropical (pineapple, mango, passion fruit)', value: 'tropical' }
       ],
       allowMultiple: true
     }
   },
   {
-    id: 'aroma_appeal',
-    section: 'aroma',
+    id: 'fruit-rate',
+    section: 'fruit',
     type: 'scale',
+    beatType: 'rate',
+    preferenceDirection: 'more',
     config: {
-      title: 'How appealing is the aroma?',
-      description: 'Do you like what you smell?',
+      title: 'How much do you enjoy these fruit flavors?',
+      description: 'Would you want more or less fruit intensity in your next wine?',
       scaleMin: 1,
-      scaleMax: 5,
-      scaleLabels: ['Not my style', 'Love it']
+      scaleMax: 10,
+      scaleLabels: ['Not my style', 'Love them']
     }
   },
-
-  // TASTE SECTION (5 questions) - Core preference sliders
+  // --- BODY (notice + rate) ---
   {
-    id: 'taste_sweetness',
-    section: 'taste',
+    id: 'body-notice',
+    section: 'body',
     type: 'scale',
+    beatType: 'notice',
+    educationalNote: 'This weight is called "body." It comes from alcohol, sugar, and extract in the wine. Full-bodied wines feel richer and coat your mouth more.',
     config: {
-      title: 'How do you like the sweetness?',
-      description: 'Rate where this wine lands for you.',
+      title: 'How heavy does the wine feel in your mouth?',
+      description: 'Think of it like milk: skim milk is light-bodied, whole milk is medium, cream is full-bodied.',
       scaleMin: 1,
-      scaleMax: 5,
-      scaleLabels: ['Bone Dry', 'Sweet']
-    }
-  },
-  {
-    id: 'taste_acidity',
-    section: 'taste',
-    type: 'scale',
-    config: {
-      title: 'How do you like the acidity?',
-      description: 'That refreshing, mouth-watering quality.',
-      scaleMin: 1,
-      scaleMax: 5,
-      scaleLabels: ['Soft', 'Crisp & Zesty']
+      scaleMax: 10,
+      scaleLabels: ['Light and delicate', 'Full and rich']
     }
   },
   {
-    id: 'taste_tannins',
-    section: 'taste',
+    id: 'body-rate',
+    section: 'body',
     type: 'scale',
+    beatType: 'rate',
+    preferenceDirection: 'more',
     config: {
-      title: 'How do you like the tannins?',
-      description: 'The drying, grippy sensation (mainly in reds).',
+      title: 'Do you enjoy this body style?',
       scaleMin: 1,
-      scaleMax: 5,
-      scaleLabels: ['Silky Smooth', 'Bold & Grippy']
+      scaleMax: 10,
+      scaleLabels: ['Prefer lighter wines', 'Prefer fuller wines']
+    }
+  },
+  // --- ACIDITY (notice + rate) ---
+  {
+    id: 'acidity-notice',
+    section: 'acidity',
+    type: 'scale',
+    beatType: 'notice',
+    educationalNote: 'That bright, mouth-watering sensation is acidity. It\'s what makes wine feel refreshing rather than flat. Higher acidity wines pair beautifully with food.',
+    config: {
+      title: 'How much zing or crispness do you notice?',
+      description: 'Pay attention to whether your mouth waters after you swallow. More watering = more acidity.',
+      scaleMin: 1,
+      scaleMax: 10,
+      scaleLabels: ['Soft and smooth', 'Bright and zingy']
     }
   },
   {
-    id: 'taste_body',
-    section: 'taste',
+    id: 'acidity-rate',
+    section: 'acidity',
     type: 'scale',
+    beatType: 'rate',
+    preferenceDirection: 'more',
     config: {
-      title: 'How do you like the body?',
-      description: 'The weight and richness in your mouth.',
+      title: 'Do you enjoy this level of acidity?',
       scaleMin: 1,
-      scaleMax: 5,
-      scaleLabels: ['Light & Delicate', 'Full & Rich']
+      scaleMax: 10,
+      scaleLabels: ['Prefer softer wines', 'Love the zing']
+    }
+  },
+  // --- TANNINS (notice + rate) ---
+  {
+    id: 'tannins-notice',
+    section: 'tannins',
+    type: 'scale',
+    beatType: 'notice',
+    educationalNote: 'That drying feeling is called tannin — it comes from grape skins, seeds, and sometimes oak barrels. Tannins add structure and help wines age well.',
+    config: {
+      title: 'How much does this wine dry out your mouth?',
+      description: 'Focus on your gums and the sides of your tongue. Do they feel smooth, or is there a drying, slightly rough sensation — like over-steeped tea?',
+      scaleMin: 1,
+      scaleMax: 10,
+      scaleLabels: ['Silky smooth', 'Grippy and drying']
     }
   },
   {
-    id: 'taste_flavors',
-    section: 'taste',
+    id: 'tannins-rate',
+    section: 'tannins',
+    type: 'scale',
+    beatType: 'rate',
+    preferenceDirection: 'more',
+    config: {
+      title: 'Do you enjoy this level of tannin?',
+      description: 'Some people love that grippy feeling, others prefer smoother wines.',
+      scaleMin: 1,
+      scaleMax: 10,
+      scaleLabels: ['Prefer smoother', 'Love the grip']
+    }
+  },
+  // --- SECONDARY AROMAS (notice + rate) ---
+  {
+    id: 'secondary-notice',
+    section: 'secondary',
     type: 'multiple_choice',
+    beatType: 'notice',
+    educationalNote: 'These are called secondary and tertiary aromas. They come from fermentation (floral, herbal notes) and aging (vanilla, toast, leather). They\'re what make each wine unique.',
     config: {
-      title: 'What flavors stand out?',
-      description: 'Select all that you taste.',
+      title: 'Beyond the fruit, do you notice any other aromas?',
+      description: 'Give the glass another swirl and take a deeper sniff. These "secondary" aromas add complexity.',
       options: [
-        { id: 'fruit', text: 'Fruity', value: 'fruit' },
-        { id: 'spice', text: 'Spicy', value: 'spice' },
-        { id: 'oak', text: 'Oaky/Toasty', value: 'oak' },
-        { id: 'mineral', text: 'Mineral/Chalky', value: 'mineral' },
-        { id: 'herbal', text: 'Herbal/Green', value: 'herbal' },
-        { id: 'earthy', text: 'Earthy', value: 'earthy' }
+        { id: 'herbal', text: 'Herbal (mint, eucalyptus, bell pepper)', value: 'herbal' },
+        { id: 'floral', text: 'Floral (rose, violet, honeysuckle)', value: 'floral' },
+        { id: 'earthy', text: 'Earthy (mushroom, soil, forest floor)', value: 'earthy' },
+        { id: 'oaky', text: 'Oaky (vanilla, toast, baking spices)', value: 'oaky' },
+        { id: 'none', text: 'Not really noticing any', value: 'none' }
       ],
       allowMultiple: true
     }
   },
-
-  // OVERALL SECTION (3 questions) - Summary and preference
   {
-    id: 'overall_rating',
+    id: 'secondary-rate',
+    section: 'secondary',
+    type: 'scale',
+    beatType: 'rate',
+    preferenceDirection: 'more',
+    config: {
+      title: 'How do you feel about these extra aromas?',
+      description: 'Do they add to your enjoyment or distract from the fruit?',
+      scaleMin: 1,
+      scaleMax: 10,
+      scaleLabels: ['Prefer simpler wines', 'Love the complexity']
+    }
+  },
+  // --- OVERALL (no beatType — standard ending) ---
+  {
+    id: 'overall-rating',
     section: 'overall',
     type: 'scale',
     config: {
-      title: 'How would you rate this wine?',
-      description: 'Your overall impression.',
+      title: 'Overall, how much do you enjoy this wine?',
+      description: 'Think about the full experience — the smell, the taste, the aftertaste. Would you be happy if someone poured you another glass?',
       scaleMin: 1,
-      scaleMax: 5,
-      scaleLabels: ['Not for me', 'Excellent']
+      scaleMax: 10,
+      scaleLabels: ['Not for me', 'Love it!']
     }
   },
   {
-    id: 'overall_buy_again',
+    id: 'overall-buy-again',
     section: 'overall',
-    type: 'boolean',
+    type: 'multiple_choice',
     config: {
       title: 'Would you buy this wine again?',
-      description: 'Would you pick this up at the store?'
+      options: [
+        { id: 'yes', text: 'Yes, definitely!', value: 'yes' },
+        { id: 'maybe', text: 'Maybe, at the right price', value: 'maybe' },
+        { id: 'no', text: 'No, not for me', value: 'no' }
+      ]
     }
   },
   {
-    id: 'overall_notes',
+    id: 'overall-notes',
     section: 'overall',
     type: 'text',
     config: {
-      title: 'Any final thoughts?',
-      description: 'Optional: jot down what you liked or didn\'t like.',
+      title: 'Any thoughts you want to remember about this wine?',
+      description: 'What stood out? What would you tell a friend about it?',
       placeholder: 'e.g., "Great with the steak!", "Too tannic for me", "Perfect summer wine"',
       rows: 3
     }
   }
 ];
 
-// Section info for headers - 5 core components + chapter focus
+// Section info for headers - 6 core components + chapter focus
 const SECTIONS: Record<string, { name: string; icon: any; color: string }> = {
   fruit: { name: 'Fruit Flavors', icon: Grape, color: 'from-red-500 to-pink-500' },
   secondary: { name: 'Secondary Notes', icon: Droplets, color: 'from-purple-500 to-indigo-500' },
   tertiary: { name: 'Aged Character', icon: Wine, color: 'from-amber-500 to-orange-500' },
   body: { name: 'Body & Texture', icon: Wine, color: 'from-rose-500 to-red-500' },
   acidity: { name: 'Acidity', icon: Droplets, color: 'from-yellow-500 to-lime-500' },
+  tannins: { name: 'Tannins', icon: Wine, color: 'from-stone-500 to-stone-700' },
   overall: { name: 'Overall', icon: Star, color: 'from-emerald-500 to-teal-500' },
   // Legacy sections for fallback questions
   aroma: { name: 'Aroma', icon: Droplets, color: 'from-purple-500 to-pink-500' },
@@ -261,6 +326,7 @@ function convertAIQuestions(questions: AIQuestion[]): TastingQuestion[] {
     'tertiary': 'tertiary',
     'body': 'body',
     'acidity': 'acidity',
+    'tannins': 'tannins',
     'overall': 'overall',
     'appearance': 'visual',
     'aroma': 'aroma',
@@ -270,7 +336,7 @@ function convertAIQuestions(questions: AIQuestion[]): TastingQuestion[] {
   };
 
   return questions
-    .filter(q => q && q.title && q.title.trim()) // Filter out questions with empty titles
+    .filter(q => q && q.title && q.title.trim())
     .map((q) => ({
     id: q.id,
     section: categoryToSection[q.category] || 'taste',
@@ -279,21 +345,22 @@ function convertAIQuestions(questions: AIQuestion[]): TastingQuestion[] {
     config: {
       title: q.title,
       description: q.description || q.wineContext,
-      // Scale config
       scaleMin: q.scaleMin,
       scaleMax: q.scaleMax,
       scaleLabels: q.scaleLabels,
-      // Multiple choice config
       options: q.options?.map(opt => ({
         id: opt.id,
         text: opt.text,
         value: opt.id
       })),
       allowMultiple: q.allowMultiple,
-      // Text config
       placeholder: q.questionType === 'text' ? 'Share your observations...' : undefined,
       rows: q.questionType === 'text' ? 3 : undefined
-    }
+    },
+    // Pass through three-beat metadata
+    beatType: q.beatType,
+    educationalNote: q.educationalNote,
+    preferenceDirection: q.preferenceDirection,
   }));
 }
 
@@ -306,6 +373,7 @@ export default function SoloTastingSession({ wine, onComplete, onCancel, chapter
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [savedTastingId, setSavedTastingId] = useState<number | undefined>();
+  const [showEducationalNote, setShowEducationalNote] = useState(false);
 
   // localStorage auto-save for crash protection
   const STORAGE_KEY = `cata-tasting-draft-${wine?.wineName || 'unknown'}`;
@@ -392,6 +460,7 @@ export default function SoloTastingSession({ wine, onComplete, onCancel, chapter
       tertiary: 'aroma',
       body: 'structure',
       acidity: 'structure',
+      tannins: 'taste',
     };
 
     // Collect chapter prompt answers separately
@@ -429,35 +498,65 @@ export default function SoloTastingSession({ wine, onComplete, onCancel, chapter
 
   /**
    * Map AI-generated question answers to the canonical field paths the backend expects.
-   * AI questions have arbitrary IDs producing unpredictable field names, but the backend
-   * reads hardcoded paths like taste.sweetness, taste.acidity, etc.
+   * Uses explicit canonical ID matching first, then falls back to keyword heuristics.
    */
   function normalizeCanonicalFields(
     responses: TastingResponses,
     questions: TastingQuestion[],
     allAnswers: Record<string, any>
   ) {
+    // Explicit canonical ID → field mapping (three-beat IDs use notice beats for observation data)
+    const explicitIdMap: Record<string, { section: keyof TastingResponses; field: string }> = {
+      'sweetness-notice': { section: 'taste', field: 'sweetness' },
+      'acidity-notice': { section: 'taste', field: 'acidity' },
+      'tannins-notice': { section: 'taste', field: 'tannins' },
+      'body-notice': { section: 'taste', field: 'body' },
+      'overall-rating': { section: 'overall', field: 'rating' },
+      'overall-buy-again': { section: 'overall', field: 'wouldBuyAgain' },
+      // Legacy fallback IDs
+      'taste_sweetness': { section: 'taste', field: 'sweetness' },
+      'taste_acidity': { section: 'taste', field: 'acidity' },
+      'taste_tannins': { section: 'taste', field: 'tannins' },
+      'taste_body': { section: 'taste', field: 'body' },
+      'overall_rating': { section: 'overall', field: 'rating' },
+      'overall_buy_again': { section: 'overall', field: 'wouldBuyAgain' },
+    };
+
+    // First pass: explicit ID matching
+    for (const q of questions) {
+      const answer = allAnswers[q.id];
+      if (answer === undefined) continue;
+      const mapping = explicitIdMap[q.id];
+      if (mapping) {
+        const target = responses[mapping.section] as Record<string, any> | undefined;
+        if (target && target[mapping.field] === undefined) {
+          target[mapping.field] = answer;
+        }
+      }
+    }
+
+    // Second pass: keyword heuristics for any remaining unmapped fields
     const canonicalFields = [
       { section: 'taste' as keyof TastingResponses, field: 'sweetness', keywords: ['sweetness', 'sweet', 'residual_sugar'] },
       { section: 'taste' as keyof TastingResponses, field: 'acidity', keywords: ['acidity', 'acid', 'tartness', 'crisp'] },
       { section: 'taste' as keyof TastingResponses, field: 'tannins', keywords: ['tannin', 'tannins', 'tannic', 'astringent'] },
       { section: 'taste' as keyof TastingResponses, field: 'body', keywords: ['body', 'weight', 'fullness', 'mouthfeel'] },
-      { section: 'overall' as keyof TastingResponses, field: 'rating', keywords: ['rating', 'overall', 'score'] },
+      { section: 'overall' as keyof TastingResponses, field: 'rating', keywords: ['rating', 'overall_rating', 'score'] },
     ];
 
     for (const { section, field, keywords } of canonicalFields) {
       const target = responses[section] as Record<string, any> | undefined;
       if (!target || target[field] !== undefined) continue;
 
-      // Also check the structure section (AI body/acidity questions map there)
       const structureTarget = responses.structure as Record<string, any> | undefined;
       if (structureTarget?.[field] !== undefined) {
         target[field] = structureTarget[field];
         continue;
       }
 
-      // Search AI questions for semantic match
       for (const q of questions) {
+        // Only map notice-beat questions (observations), not rate-beat (preferences)
+        if (q.beatType === 'rate') continue;
         const answer = allAnswers[q.id];
         if (answer === undefined) continue;
         const idLower = q.id.toLowerCase();
@@ -467,6 +566,27 @@ export default function SoloTastingSession({ wine, onComplete, onCancel, chapter
           break;
         }
       }
+    }
+
+    // Third pass: collect preference data from rate-beat questions
+    const preferences: Record<string, { enjoyment: number; wantMore: boolean }> = {};
+    for (const q of questions) {
+      if (q.beatType !== 'rate') continue;
+      const answer = allAnswers[q.id];
+      if (answer === undefined || typeof answer !== 'number') continue;
+
+      // Extract trait name from ID (e.g., "tannins-rate" → "tannins")
+      const trait = q.id.replace(/-rate$/, '');
+      if (trait) {
+        preferences[trait] = {
+          enjoyment: answer,
+          wantMore: q.preferenceDirection === 'more' ? answer >= 6 : answer <= 4,
+        };
+      }
+    }
+
+    if (Object.keys(preferences).length > 0) {
+      responses.preferences = preferences;
     }
   }
 
@@ -518,6 +638,15 @@ export default function SoloTastingSession({ wine, onComplete, onCancel, chapter
   };
 
   const handleNext = () => {
+    // If this is a notice-beat question with an educational note, show it first
+    if (currentQuestion?.beatType === 'notice' && currentQuestion.educationalNote && !showEducationalNote) {
+      setShowEducationalNote(true);
+      return;
+    }
+
+    // Dismiss educational note and advance
+    setShowEducationalNote(false);
+
     if (currentQuestionIndex < allQuestions.length - 1) {
       setCurrentQuestionIndex(prev => prev + 1);
     } else {
@@ -528,6 +657,7 @@ export default function SoloTastingSession({ wine, onComplete, onCancel, chapter
   };
 
   const handlePrevious = () => {
+    setShowEducationalNote(false);
     if (currentQuestionIndex > 0) {
       setCurrentQuestionIndex(prev => prev - 1);
     }
@@ -723,15 +853,47 @@ export default function SoloTastingSession({ wine, onComplete, onCancel, chapter
       {/* Question Content */}
       <main className="container mx-auto px-4 py-6 pb-32">
         <AnimatePresence mode="wait">
-          <motion.div
-            key={currentQuestion?.id}
-            initial={{ opacity: 0, x: 20 }}
-            animate={{ opacity: 1, x: 0 }}
-            exit={{ opacity: 0, x: -20 }}
-            transition={{ duration: 0.2 }}
-          >
-            {renderQuestion()}
-          </motion.div>
+          {showEducationalNote && currentQuestion?.educationalNote ? (
+            <motion.div
+              key={`${currentQuestion.id}-edu`}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.3 }}
+              className="max-w-lg mx-auto"
+            >
+              <div className="bg-white/10 backdrop-blur-md rounded-2xl p-6 border border-white/20 shadow-xl">
+                <div className="flex items-start gap-3 mb-4">
+                  <div className="w-8 h-8 rounded-full bg-gradient-to-r from-amber-400 to-orange-400 flex items-center justify-center flex-shrink-0 mt-0.5">
+                    <Wine className="w-4 h-4 text-white" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-amber-300 mb-1">Did you know?</p>
+                    <p className="text-white/90 text-base leading-relaxed">
+                      {currentQuestion.educationalNote}
+                    </p>
+                  </div>
+                </div>
+                <Button
+                  onClick={handleNext}
+                  className="w-full bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white py-3 rounded-xl mt-2"
+                >
+                  Got it — next question
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </Button>
+              </div>
+            </motion.div>
+          ) : (
+            <motion.div
+              key={currentQuestion?.id}
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.2 }}
+            >
+              {renderQuestion()}
+            </motion.div>
+          )}
         </AnimatePresence>
       </main>
 

--- a/docs/plans/2026-03-03-feat-learning-journey-enhancement-plan.md
+++ b/docs/plans/2026-03-03-feat-learning-journey-enhancement-plan.md
@@ -1,0 +1,482 @@
+---
+title: "feat: Learning Journey Enhancement — Questions, Wine Guidance, Nearby Shops"
+type: feat
+date: 2026-03-03
+supersedes: docs/plans/2026-02-20-feat-preference-focused-tasting-questions-plan.md
+---
+
+# Learning Journey Enhancement
+
+## Overview
+
+Three connected improvements to the Learning Journeys experience:
+
+1. **Three-Beat Question Loop** — Restructure AI-generated tasting questions into a notice→explain→rate pattern that builds preference profiles over time
+2. **Dual Wine Recommendations** — Show a "Budget" (under $25) and "Splurge" option for each wine in a chapter, with rich shopping companion guidance
+3. **Nearby Wine Shops** — Google Places API integration to help users find where to buy
+
+This plan supersedes `2026-02-20-feat-preference-focused-tasting-questions-plan.md` and incorporates its Phase 1 data pipeline fixes as prerequisites.
+
+## Problem Statement
+
+**Questions are flat.** The AI prompt says "focus on enjoyment" but doesn't enforce a pedagogical structure. Users answer questions but don't learn what they're tasting or build a preference vocabulary. There's no moment of "oh, THAT's what tannin is, and I like it."
+
+**Wine acquisition is intimidating.** Users are told "buy a Cotes du Rhone" but not what that looks like on a shelf, what to ask a shop employee, or where to even go. The gap between "chapter says buy this wine" and "user has the wine in hand" is underserved.
+
+**One-size pricing doesn't fit.** A college student and a wine enthusiast shouldn't get the same $40 recommendation. But a global budget setting is too rigid — someone might go cheap on a Tuesday and splurge for a dinner party.
+
+## Proposed Solution
+
+### Three-Beat Question Loop
+
+For each sensory characteristic the AI selects as important for this wine:
+
+- **Beat 1 (Notice + Name):** Ask the user to observe something. After they answer, show an inline educational explanation naming what they just experienced. Example: User answers "dry" → app shows "That dryness is called tannin — it comes from grape skins and adds structure to the wine."
+- **Beat 2 (Rate):** Ask if they liked it and how much they want in future wines. Example: "Did you enjoy that feeling? Would you want more or less tannin in your next wine?"
+
+This is two screens per characteristic, not three — the educational content merges into Beat 1's answer as inline feedback before advancing.
+
+**Question counts by level:**
+- Beginner: 5 key traits (10 items) + overall questions
+- Intermediate: 6 key traits (12 items) + overall questions
+- Advanced: 8 key traits (16 items) + overall questions
+
+The AI picks which traits matter most for the specific wine (e.g., tannin + dark fruit + body for a Cabernet, acidity + minerality + citrus for a Sancerre).
+
+### Dual Wine Recommendations (Budget / Splurge)
+
+Each chapter shows two wine cards:
+
+- **Budget:** Accessible option, kept under ~$25. Shows name, region, what to look for, what to ask.
+- **Splurge:** Premium version. Same info but no price shown — "you'll know the price when you see it."
+
+User picks per-wine, per-chapter. No global setting. Same lesson either way.
+
+### Wine Acquisition Shopping Companion
+
+For each wine option, AI-generated guidance that answers:
+- What to look for on the label (producer names, region text, grape mention)
+- What to say to shop staff ("I'm looking for a Southern Rhone blend, something GSM")
+- Acceptable substitutes if they can't find the exact wine
+
+Generated at journey authoring time (not tasting time) so it's always ready.
+
+### Nearby Wine Shops
+
+Google Places API (New) integration:
+- Server-side proxy at `/api/wine-shops/nearby` to protect API key
+- Client-side browser geolocation
+- Show list: name, address, rating, tap-to-open-in-maps
+- Grid-based caching (30-min TTL) keeps API costs at zero for small user base
+
+---
+
+## Technical Approach
+
+### Architecture
+
+```
+Journey Authoring (Admin)
+  └── AI generates shopping companion text per wine option
+  └── Sommelier reviews/edits, publishes
+
+Journey Experience (User)
+  ├── JourneyDetail: browse chapters, see budget/splurge wine options + shopping guide
+  │   ├── WineOptionCard (budget): name, guidance, "under $25"
+  │   ├── WineOptionCard (splurge): name, guidance, no price
+  │   └── NearbyWineShops: geolocation → Google Places → shop list
+  │
+  └── SoloTastingSession: three-beat question loop
+      ├── Beat 1: Notice + inline educational explanation after answer
+      ├── Beat 2: Rate preference (scale 1-10)
+      ├── ... repeat for AI-selected traits ...
+      ├── Overall rating (1-10)
+      ├── Would buy again? (boolean)
+      └── Final notes (text)
+
+Preference Aggregation
+  └── Beat 2 "Rate" answers accumulate across tastings
+  └── Future: "You tend to prefer low-tannin, high-acidity wines"
+```
+
+### Implementation Phases
+
+#### Phase 0: Data Pipeline Fixes (Prerequisite)
+
+Fixes from the superseded plan that must ship first.
+
+**0A. Standardize rating scale to 1-10**
+
+All scale questions across static, fallback, and AI-generated flows must use 1-10. Currently mixed.
+
+| File | Change |
+|------|--------|
+| `client/src/pages/SoloTastingSession.tsx` | Update `TASTING_QUESTIONS` scales from `scaleMax: 5` → `10` |
+| `client/src/pages/SoloTastingDetail.tsx` | Update star display to 1-10 scale bar |
+| `client/src/components/questions/ScaleQuestion.tsx` | Verify 1-10 range works |
+| `server/services/questionGenerator.ts` | Update system prompt: 1-10 for ALL scales |
+| `server/services/questionGenerator.ts` | Update `FALLBACK_QUESTIONS` from `scaleMax: 5` → `10` |
+
+**0B. Add tannins category**
+
+| File | Change |
+|------|--------|
+| `server/services/questionGenerator.ts` | Add tannins as 6th core component (reds/rosé only) |
+| `server/services/questionGenerator.ts` | Add tannins fallback questions |
+| `shared/schema.ts` | Add `'tannins'` to `QuestionCategory` type |
+
+**0C. Increase `max_completion_tokens`**
+
+| File | Change |
+|------|--------|
+| `server/services/questionGenerator.ts` ~line 271 | Level-dependent: beginner=3000, intermediate=3500, advanced=4500 |
+
+**0D. Add "Would you buy again?"**
+
+| File | Change |
+|------|--------|
+| `server/services/questionGenerator.ts` | Add instruction to always include boolean buy-again |
+| `server/services/questionGenerator.ts` | Add `overall-buy-again` to `FALLBACK_QUESTIONS` |
+
+---
+
+#### Phase 1: Three-Beat Question Loop
+
+**1A. Extend `GeneratedQuestion` schema**
+
+Add fields to support the two-beat structure and inline education.
+
+```typescript
+// shared/schema.ts — extend GeneratedQuestion interface (line ~1074)
+
+interface GeneratedQuestion {
+  // ... existing fields ...
+  beatType: 'notice' | 'rate';           // NEW: which beat this question is
+  educationalNote?: string;               // NEW: shown after user answers a 'notice' beat
+  preferenceDirection?: 'more' | 'less';  // NEW: for rate beats, what "high" means for preference
+}
+```
+
+- `beatType: 'notice'` — The observation question ("Does this make your mouth feel dry?")
+- `beatType: 'rate'` — The preference question ("Did you enjoy that? More or less next time?")
+- `educationalNote` — Displayed inline after the user answers a `notice` beat, before advancing to the paired `rate` beat. Example: "That dryness is called tannin — it comes from grape skins."
+- Questions without `beatType` (legacy, overall) render as before
+
+**Files:**
+| File | Change |
+|------|--------|
+| `shared/schema.ts` ~line 1074 | Add `beatType`, `educationalNote`, `preferenceDirection` to `GeneratedQuestion` |
+| `shared/schema.ts` ~line 27 (questionGenerator.ts) | Update `GeneratedQuestionSchema` zod schema to include new fields |
+
+**1B. Rewrite AI system/user prompts**
+
+Restructure `getSystemPrompt()` and `getUserPrompt()` in `questionGenerator.ts` to produce the two-beat structure.
+
+**New system prompt principles:**
+1. You are helping someone discover what they like, not testing knowledge
+2. For each characteristic, generate a paired notice+rate:
+   - Notice question: guide the user to observe (everyday language for beginners)
+   - `educationalNote`: 1-2 sentences explaining what they just noticed
+   - Rate question: ask if they enjoyed it, would they want more or less
+3. Pick the most interesting traits for THIS wine:
+   - Beginner: 5 traits
+   - Intermediate: 6 traits
+   - Advanced: 8 traits
+4. Always include overall rating (1-10) and buy-again (boolean) at the end
+5. Every scale uses 1-10
+6. Required canonical IDs for reliable mapping:
+   - `sweetness-notice`, `sweetness-rate` → `taste.sweetness`
+   - `acidity-notice`, `acidity-rate` → `taste.acidity`
+   - `body-notice`, `body-rate` → `taste.body`
+   - `tannins-notice`, `tannins-rate` → `taste.tannins` (reds only)
+   - `overall-rating` → `overall.rating`
+   - `buy-again` → `overall.wouldBuyAgain`
+
+**Files:**
+| File | Change |
+|------|--------|
+| `server/services/questionGenerator.ts` lines 324-363 | Rewrite `getSystemPrompt()` |
+| `server/services/questionGenerator.ts` lines 365-437 | Rewrite `getUserPrompt()` with trait count per level |
+
+**1C. Update `SoloTastingSession` rendering for two-beat flow**
+
+After the user answers a `notice` beat question, show the `educationalNote` as an inline card/toast before advancing to the paired `rate` question.
+
+```
+[User sees notice question] → [User answers] → [Educational note animates in] → [User taps "Got it" or auto-advance after 3s] → [Rate question appears]
+```
+
+**Files:**
+| File | Change |
+|------|--------|
+| `client/src/pages/SoloTastingSession.tsx` | Add educational note display after notice-beat answers |
+| `client/src/pages/SoloTastingSession.tsx` | Update `convertAIQuestions()` to handle `beatType` |
+| `client/src/pages/SoloTastingSession.tsx` lines 435-471 | Update `normalizeCanonicalFields()` with explicit canonical IDs |
+
+**1D. Add preference storage**
+
+Beat 2 "rate" answers are preference signals distinct from observation answers. Store them so they can be aggregated over time.
+
+```typescript
+// shared/schema.ts — extend TastingResponses (line ~744)
+
+interface TastingResponses {
+  // ... existing observation sections ...
+  preferences?: {
+    [characteristic: string]: {
+      enjoyment: number;        // 1-10: how much they liked it
+      wantMore: boolean;        // would they want more of this in future wines
+    }
+  }
+}
+```
+
+**Files:**
+| File | Change |
+|------|--------|
+| `shared/schema.ts` ~line 744 | Add `preferences` section to `TastingResponses` |
+| `client/src/pages/SoloTastingSession.tsx` | Map `rate` beat answers to `preferences` section in save |
+
+**1E. Update fallback questions to two-beat structure**
+
+Replace `FALLBACK_QUESTIONS` with a static two-beat set covering 5 core traits (body, acidity, tannins, fruit, aroma) plus overall. Used when AI is unavailable.
+
+**Files:**
+| File | Change |
+|------|--------|
+| `server/services/questionGenerator.ts` lines 61-190 | Rewrite `FALLBACK_QUESTIONS` with notice+rate pairs |
+| `client/src/pages/SoloTastingSession.tsx` lines 88-222 | Rewrite `TASTING_QUESTIONS` to match |
+
+---
+
+#### Phase 2: Dual Wine Recommendations + Shopping Companion
+
+**2A. Simplify `WineOption.level` to budget/splurge**
+
+The existing `entry | mid | premium` enum maps naturally to budget/splurge. Change the enum and update existing data.
+
+```typescript
+// shared/schema.ts — update WineOption interface (line ~995)
+
+interface WineOption {
+  description: string;
+  askFor: string;
+  labelTips?: string;          // NEW: what to look for on the label
+  substitutes?: string[];      // NEW: acceptable alternatives (moved from chapter-level)
+  priceRange?: PriceRange;     // optional — omit for splurge
+  exampleProducers?: string[];
+  level: 'budget' | 'splurge'; // CHANGED from 'entry' | 'mid' | 'premium'
+  whyThisWine?: string;
+}
+```
+
+**Files:**
+| File | Change |
+|------|--------|
+| `shared/schema.ts` ~line 995 | Change `level` enum, add `labelTips`, `substitutes` |
+| `client/src/components/WineOptionCard.tsx` | Update to render budget vs splurge (hide price for splurge) |
+| `client/src/pages/JourneyDetail.tsx` | Update `WineOptionsList` rendering for two-card layout |
+
+**2B. Wire up wine option selection through navigation**
+
+Currently `onSelectOption` in `JourneyDetail` is not connected. Pass the selection to `SoloTastingNew`.
+
+**Files:**
+| File | Change |
+|------|--------|
+| `client/src/pages/JourneyDetail.tsx` ~line 151 | Pass `selectedLevel` as URL param in `handleStartChapter` |
+| `client/src/pages/JourneyDetail.tsx` ~line 483 | Wire up `onSelectOption` callback |
+| `client/src/pages/SoloTastingNew.tsx` | Read `selectedLevel` from URL, show relevant shopping guide |
+
+**2C. AI shopping companion generation (admin)**
+
+Add an endpoint and admin UI button for generating shopping companion text per wine option.
+
+```
+POST /api/admin/chapters/:chapterId/generate-shopping-guide
+Body: { wineRequirements: {...} }
+Response: { wineOptions: WineOption[] }
+```
+
+The AI prompt takes wine requirements (grape, region, style) and generates:
+- Budget option: name, description, askFor, labelTips, substitutes, priceRange (max: 25)
+- Splurge option: name, description, askFor, labelTips, substitutes (no priceRange)
+
+Sommelier can review and edit the result before saving.
+
+**Files:**
+| File | Change |
+|------|--------|
+| `server/routes/journeys.ts` | Add `POST /api/admin/chapters/:chapterId/generate-shopping-guide` |
+| `server/services/shoppingGuideGenerator.ts` | NEW: AI prompt for generating shopping companion text |
+| `client/src/pages/PackageEditor.tsx` or admin chapter editor | Add "Generate Shopping Guide" button |
+
+**2D. Update `WineOptionCard` UI**
+
+Two cards side-by-side (desktop) or stacked (mobile):
+
+```
+┌─────────────────────┐  ┌─────────────────────┐
+│  BUDGET              │  │  SPLURGE             │
+│  Under $25           │  │                      │
+│                      │  │                      │
+│  Cotes du Ventoux    │  │  Chateauneuf-du-Pape │
+│  Southern Rhone      │  │  Southern Rhone      │
+│                      │  │                      │
+│  Look for: "Ventoux" │  │  Look for: "CDP" or  │
+│  on the label        │  │  "Chateauneuf" on    │
+│                      │  │  the label           │
+│  Ask for: "A Cotes   │  │                      │
+│  du Ventoux — it's   │  │  Ask for: "Your best │
+│  like a baby Chatea- │  │  Chateauneuf-du-Pape"│
+│  uneuf"              │  │                      │
+│                      │  │  Also works:         │
+│  Also works:         │  │  Gigondas, Vacqueyras│
+│  Any Southern Rhone  │  │                      │
+│       [Select]       │  │       [Select]       │
+└─────────────────────┘  └─────────────────────┘
+```
+
+**Files:**
+| File | Change |
+|------|--------|
+| `client/src/components/WineOptionCard.tsx` | Redesign for budget/splurge with labelTips, substitutes |
+
+---
+
+#### Phase 3: Nearby Wine Shops (Google Places API)
+
+**3A. Server-side proxy endpoint**
+
+```
+GET /api/wine-shops/nearby?latitude=X&longitude=Y&radius=5000
+Response: { shops: [{ id, name, address, rating, ratingCount, lat, lng }] }
+```
+
+- Uses Google Places API (New) `POST /v1/places:searchNearby`
+- `includedTypes: ["liquor_store"]` (no `wine_store` type exists in Google)
+- Field mask: `places.id,places.displayName,places.formattedAddress,places.location,places.rating,places.userRatingCount,places.businessStatus`
+- Enterprise tier: 1,000 free requests/month (plenty with caching)
+- Input validation on coordinates
+- Rate limited: 20 requests/min per IP
+- Grid-based cache: round coordinates to 2 decimal places (~1.1km), 30-min TTL
+- Env var: `GOOGLE_PLACES_API_KEY`
+
+**Files:**
+| File | Change |
+|------|--------|
+| `server/routes/places.ts` | NEW: `/api/wine-shops/nearby` proxy endpoint with caching |
+| `server/routes.ts` or app setup | Register new route file |
+
+**3B. Client geolocation hook**
+
+```typescript
+// client/src/hooks/useGeolocation.ts — NEW
+// Returns { position, error, loading, requestLocation }
+// Uses navigator.geolocation with enableHighAccuracy: false, 10s timeout, 5-min cache
+```
+
+**Files:**
+| File | Change |
+|------|--------|
+| `client/src/hooks/useGeolocation.ts` | NEW: `useGeolocation()` hook |
+
+**3C. Nearby shops UI component**
+
+Placed on the `JourneyDetail` chapter view, below the wine options. Shows:
+- "Find wine shops near you" button (triggers geolocation permission)
+- List of shops: name, address, star rating, tap to open in native maps
+- Loading state while fetching
+- Permission-denied state: message explaining how to enable location in device settings
+- Empty state (no shops nearby): "No wine shops found nearby. Try a larger area or check online retailers."
+- Shops open in Apple Maps (iOS) or Google Maps (Android/desktop) via `https://maps.google.com/?q=lat,lng` or `maps://` scheme
+
+**Files:**
+| File | Change |
+|------|--------|
+| `client/src/components/NearbyWineShops.tsx` | NEW: nearby shops component |
+| `client/src/pages/JourneyDetail.tsx` | Add `NearbyWineShops` below wine options per chapter |
+
+**3D. Privacy considerations**
+
+- Coordinates are sent to our server only to proxy to Google — NOT stored in database, NOT logged
+- Add brief explanation before requesting permission: "We'll use your location to find wine shops nearby. Your location is not stored."
+- No GDPR consent form needed — location is used transiently and not persisted
+
+---
+
+## Acceptance Criteria
+
+### Three-Beat Questions
+- [x] AI-generated questions follow notice→(educational note)→rate pattern per characteristic
+- [x] Beginner gets 5 traits, intermediate 6, advanced 8 (AI picks which traits)
+- [x] Educational note displays inline after answering a notice question
+- [x] Rate answers stored in `preferences` section of `TastingResponses`
+- [x] All scales use 1-10 consistently
+- [x] Tannins included for reds/rosé, omitted for whites
+- [x] "Would you buy again?" boolean always included
+- [x] Fallback questions also follow the two-beat structure
+- [x] `normalizeCanonicalFields()` uses explicit canonical IDs, not just keyword matching
+- [x] Historical tastings display correctly (backward compatible)
+
+### Dual Wine Recommendations
+- [x] Each chapter shows budget and splurge wine options side-by-side
+- [x] Budget option shows "Under $25" — splurge shows no price
+- [x] Each option includes: description, what to ask, label tips, substitutes
+- [x] User selection persists through navigation to `SoloTastingNew`
+- [x] Admin can trigger AI generation of shopping guide per chapter
+- [ ] Admin can edit AI-generated shopping guide before publishing
+- [x] Chapters without wine options gracefully show old-style shopping tips
+
+### Nearby Wine Shops
+- [x] "Find wine shops near you" button on chapter view
+- [x] Shows list of shops with name, address, rating
+- [x] Tapping a shop opens native maps app
+- [x] Graceful handling of: permission denied, no results, API error
+- [x] API key never exposed to client
+- [x] Results cached (30-min TTL, grid-based)
+- [x] Location not stored or logged
+
+## Dependencies & Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| AI prompt changes break question format | High | Explicit canonical IDs + zod validation + fallback questions |
+| `max_completion_tokens` still insufficient for 8-trait advanced | Medium | Level-dependent limits (3000/3500/4500); monitor fallback rate |
+| Three-beat loop makes sessions too long | Medium | AI picks only relevant traits; user can skip; test with real users |
+| Google Places API costs escalate | Low | Grid-based caching, rate limiting, 1k free/month is plenty for early stage |
+| Wine price recommendations inaccurate | Medium | No specific prices for splurge; "under $25" is a guideline, not a guarantee |
+| `WineOption.level` enum change breaks existing data | Medium | DB migration to map `entry`→`budget`, `premium`→`splurge`, drop `mid`; or keep both with aliasing |
+| localStorage drafts from old schema | Low | Add `schemaVersion` to draft JSON; clear stale drafts on mismatch |
+
+## Implementation Order
+
+1. **Phase 0** — Data pipeline fixes. Deploy and verify.
+2. **Phase 1** — Three-beat question loop. Core learning improvement.
+3. **Phase 2** — Dual wine options + shopping companion. Complete the acquisition experience.
+4. **Phase 3** — Nearby wine shops. Cherry on top.
+
+Each phase is independently deployable and valuable.
+
+## References
+
+### Internal
+- `server/services/questionGenerator.ts` — Current AI prompts, fallback questions
+- `shared/schema.ts` — `GeneratedQuestion`, `TastingResponses`, `WineOption`, `chapters` table
+- `client/src/pages/SoloTastingSession.tsx` — Question rendering, normalization, save
+- `client/src/pages/JourneyDetail.tsx` — Journey/chapter UI, wine options display
+- `client/src/components/WineOptionCard.tsx` — Wine option card component
+- `client/src/pages/SoloTastingNew.tsx` — Tasting entry point, chapter context
+- `server/routes/journeys.ts` — Journey API routes including admin CRUD
+
+### Superseded Plans
+- `docs/plans/2026-02-20-feat-preference-focused-tasting-questions-plan.md` — Phase 1 fixes incorporated; prompt rewrite approach evolved into three-beat loop
+
+### Institutional Learnings
+- `docs/solutions/logic-errors/silent-data-loss-solo-tasting-saves-20260215.md` — AI category→schema mapping gotcha
+- `INSTITUTIONAL_LEARNINGS_QUESTION_GENERATION.md` — Never silently drop unmapped answers
+
+### External
+- [Google Places API (New) — Nearby Search](https://developers.google.com/maps/documentation/places/web-service/nearby-search)
+- [Google Places API Pricing](https://developers.google.com/maps/billing-and-pricing/pricing) — Enterprise tier: 1,000 free/month with rating field
+- [Place Types](https://developers.google.com/maps/documentation/places/web-service/place-types) — Use `liquor_store` (no `wine_store` type)

--- a/scripts/seed-journeys.ts
+++ b/scripts/seed-journeys.ts
@@ -1,5 +1,5 @@
 import postgres from "postgres";
-import type { WineOption, PriceRange } from "@shared/schema";
+import type { WineOption } from "@shared/schema";
 
 const connectionString = process.env.DATABASE_URL;
 
@@ -15,40 +15,26 @@ const sql = postgres(connectionString, {
   idle_timeout: 30
 });
 
-// Helper to create wine options
+// Helper to create budget + splurge wine options
 function createWineOptions(
-  entry: { desc: string; askFor: string; min: number; max: number; producers: string[] },
-  mid: { desc: string; askFor: string; min: number; max: number; producers: string[] },
-  premium?: { desc: string; askFor: string; min: number; max: number; producers: string[] }
+  budget: { desc: string; askFor: string; min: number; max: number; producers: string[] },
+  splurge: { desc: string; askFor: string; producers: string[] }
 ): WineOption[] {
-  const options: WineOption[] = [
+  return [
     {
-      description: entry.desc,
-      askFor: entry.askFor,
-      priceRange: { min: entry.min, max: entry.max, currency: 'USD' },
-      exampleProducers: entry.producers,
-      level: 'entry'
+      description: budget.desc,
+      askFor: budget.askFor,
+      priceRange: { min: budget.min, max: budget.max, currency: 'USD' },
+      exampleProducers: budget.producers,
+      level: 'budget'
     },
     {
-      description: mid.desc,
-      askFor: mid.askFor,
-      priceRange: { min: mid.min, max: mid.max, currency: 'USD' },
-      exampleProducers: mid.producers,
-      level: 'mid'
+      description: splurge.desc,
+      askFor: splurge.askFor,
+      exampleProducers: splurge.producers,
+      level: 'splurge'
     }
   ];
-
-  if (premium) {
-    options.push({
-      description: premium.desc,
-      askFor: premium.askFor,
-      priceRange: { min: premium.min, max: premium.max, currency: 'USD' },
-      exampleProducers: premium.producers,
-      level: 'premium'
-    });
-  }
-
-  return options;
 }
 
 async function seedJourneys() {
@@ -77,8 +63,7 @@ async function seedJourneys() {
       // Chapter 1: Bordeaux
       const bordeauxOptions = createWineOptions(
         { desc: "Any Bordeaux Red", askFor: "Ask for a basic Bordeaux or Bordeaux Supérieur red under $20", min: 12, max: 20, producers: ["Mouton Cadet", "Dourthe"] },
-        { desc: "Médoc or Saint-Émilion", askFor: "Ask for a Médoc or Saint-Émilion, $25-45", min: 25, max: 45, producers: ["Château Gloria", "Château Larose Trintaudon"] },
-        { desc: "Classified Growth", askFor: "Ask for a Cru Bourgeois or classified growth Bordeaux", min: 50, max: 80, producers: ["Château Lynch-Bages", "Château Sociando-Mallet"] }
+        { desc: "Médoc or Saint-Émilion", askFor: "Ask for a Médoc or Saint-Émilion — worth the step up", producers: ["Château Gloria", "Château Larose Trintaudon"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -107,8 +92,7 @@ async function seedJourneys() {
       // Chapter 2: Burgundy
       const burgundyOptions = createWineOptions(
         { desc: "Bourgogne Rouge", askFor: "Ask for a Bourgogne Rouge (basic Burgundy red) under $25", min: 18, max: 25, producers: ["Louis Jadot", "Joseph Drouhin"] },
-        { desc: "Village-level Burgundy", askFor: "Ask for a village Burgundy like Gevrey-Chambertin or Volnay, $35-55", min: 35, max: 55, producers: ["Domaine Faiveley", "Bouchard Père et Fils"] },
-        { desc: "Premier Cru Burgundy", askFor: "Ask for a Premier Cru Burgundy if you want to splurge", min: 60, max: 100, producers: ["Domaine de la Romanée-Conti (village)", "Comte de Vogüé"] }
+        { desc: "Village-level Burgundy", askFor: "Ask for a village Burgundy like Gevrey-Chambertin or Volnay", producers: ["Domaine Faiveley", "Bouchard Père et Fils"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -137,8 +121,7 @@ async function seedJourneys() {
       // Chapter 3: Loire Valley White
       const loireOptions = createWineOptions(
         { desc: "Touraine Sauvignon Blanc", askFor: "Ask for a Touraine Sauvignon Blanc under $15", min: 10, max: 15, producers: ["Domaine de la Charmoise", "Guy Allion"] },
-        { desc: "Sancerre or Pouilly-Fumé", askFor: "Ask for a Sancerre or Pouilly-Fumé, $20-35", min: 20, max: 35, producers: ["Henri Bourgeois", "Pascal Jolivet"] },
-        { desc: "Single vineyard Sancerre", askFor: "Ask for a single vineyard or producer-specific Sancerre", min: 40, max: 60, producers: ["François Cotat", "Vacheron"] }
+        { desc: "Sancerre or Pouilly-Fumé", askFor: "Ask for a Sancerre or Pouilly-Fumé — classic Loire elegance", producers: ["Henri Bourgeois", "Pascal Jolivet"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -166,9 +149,8 @@ async function seedJourneys() {
 
       // Chapter 4: Champagne
       const champagneOptions = createWineOptions(
-        { desc: "Non-vintage Brut Champagne", askFor: "Ask for a non-vintage Brut Champagne under $45", min: 35, max: 45, producers: ["Moët & Chandon", "Veuve Clicquot", "Nicolas Feuillatte"] },
-        { desc: "Grower Champagne", askFor: "Ask for a grower (RM) Champagne or premium house, $50-75", min: 50, max: 75, producers: ["Pierre Gimonnet", "Larmandier-Bernier"] },
-        { desc: "Vintage Champagne", askFor: "Ask for a vintage Champagne for something special", min: 80, max: 120, producers: ["Bollinger", "Pol Roger", "Louis Roederer"] }
+        { desc: "Non-vintage Brut Champagne", askFor: "Ask for a non-vintage Brut Champagne", min: 35, max: 45, producers: ["Moët & Chandon", "Veuve Clicquot", "Nicolas Feuillatte"] },
+        { desc: "Grower Champagne", askFor: "Ask for a grower (RM) Champagne — real Champagne craft", producers: ["Pierre Gimonnet", "Larmandier-Bernier"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -217,8 +199,7 @@ async function seedJourneys() {
       // Chapter 1: Chianti
       const chiantiOptions = createWineOptions(
         { desc: "Basic Chianti", askFor: "Ask for a Chianti under $15", min: 10, max: 15, producers: ["Antinori", "Ruffino"] },
-        { desc: "Chianti Classico", askFor: "Ask for a Chianti Classico, $18-30", min: 18, max: 30, producers: ["Felsina", "Fontodi"] },
-        { desc: "Chianti Classico Riserva", askFor: "Ask for a Chianti Classico Riserva or Gran Selezione", min: 35, max: 55, producers: ["Castello di Ama", "Isole e Olena"] }
+        { desc: "Chianti Classico", askFor: "Ask for a Chianti Classico — the real deal from Tuscany", producers: ["Felsina", "Fontodi"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -246,8 +227,7 @@ async function seedJourneys() {
       // Chapter 2: Barolo
       const baroloOptions = createWineOptions(
         { desc: "Langhe Nebbiolo", askFor: "Ask for a Langhe Nebbiolo (baby Barolo) under $25", min: 18, max: 25, producers: ["Produttori del Barbaresco", "G.D. Vajra"] },
-        { desc: "Entry Barolo", askFor: "Ask for an entry-level Barolo, $35-55", min: 35, max: 55, producers: ["Pio Cesare", "Michele Chiarlo"] },
-        { desc: "Single Vineyard Barolo", askFor: "Ask for a single vineyard (cru) Barolo if available", min: 60, max: 100, producers: ["Bruno Giacosa", "Vietti"] }
+        { desc: "Entry Barolo", askFor: "Ask for a Barolo — the King of Italian wines", producers: ["Pio Cesare", "Michele Chiarlo"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -276,8 +256,7 @@ async function seedJourneys() {
       // Chapter 3: Amarone
       const amaroneOptions = createWineOptions(
         { desc: "Valpolicella Ripasso", askFor: "Ask for a Valpolicella Ripasso (baby Amarone) under $25", min: 18, max: 25, producers: ["Zenato", "Bertani"] },
-        { desc: "Entry Amarone", askFor: "Ask for an entry-level Amarone della Valpolicella, $40-60", min: 40, max: 60, producers: ["Tommasi", "Allegrini"] },
-        { desc: "Premium Amarone", askFor: "Ask for a premium or single vineyard Amarone", min: 70, max: 120, producers: ["Dal Forno Romano", "Quintarelli"] }
+        { desc: "Amarone della Valpolicella", askFor: "Ask for an Amarone — rich, concentrated, unforgettable", producers: ["Tommasi", "Allegrini"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -304,9 +283,8 @@ async function seedJourneys() {
 
       // Chapter 4: Brunello
       const brunelloOptions = createWineOptions(
-        { desc: "Rosso di Montalcino", askFor: "Ask for a Rosso di Montalcino (baby Brunello) under $30", min: 20, max: 30, producers: ["Banfi", "Caparzo"] },
-        { desc: "Entry Brunello", askFor: "Ask for an entry-level Brunello di Montalcino, $45-70", min: 45, max: 70, producers: ["Argiano", "Col d'Orcia"] },
-        { desc: "Premium Brunello", askFor: "Ask for a Riserva or single vineyard Brunello", min: 80, max: 150, producers: ["Biondi-Santi", "Casanova di Neri"] }
+        { desc: "Rosso di Montalcino", askFor: "Ask for a Rosso di Montalcino (baby Brunello)", min: 20, max: 25, producers: ["Banfi", "Caparzo"] },
+        { desc: "Brunello di Montalcino", askFor: "Ask for a Brunello di Montalcino — pure Sangiovese power", producers: ["Argiano", "Col d'Orcia"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -334,8 +312,7 @@ async function seedJourneys() {
       // Chapter 5: Super Tuscan
       const superTuscanOptions = createWineOptions(
         { desc: "Toscana IGT Red", askFor: "Ask for a Tuscan IGT red blend under $25", min: 15, max: 25, producers: ["Antinori Tignanello Sec.", "Castello di Bossi"] },
-        { desc: "Mid-tier Super Tuscan", askFor: "Ask for a Super Tuscan like Lucente or Guado al Tasso, $35-55", min: 35, max: 55, producers: ["Luce della Vite (Lucente)", "Antinori Guado al Tasso"] },
-        { desc: "Premium Super Tuscan", askFor: "Ask for Tignanello, Sassicaia, or Ornellaia", min: 100, max: 200, producers: ["Tignanello", "Sassicaia", "Ornellaia"] }
+        { desc: "Super Tuscan Blend", askFor: "Ask for a Super Tuscan like Lucente or Guado al Tasso", producers: ["Luce della Vite (Lucente)", "Antinori Guado al Tasso"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -479,8 +456,7 @@ async function seedJourneys() {
       // Chapter 1: Cabernet Sauvignon
       const cabOptions = createWineOptions(
         { desc: "California Cabernet under $20", askFor: "Ask for a California Cabernet Sauvignon under $20", min: 12, max: 20, producers: ["Josh Cellars", "Bogle", "14 Hands"] },
-        { desc: "Napa or Sonoma Cabernet", askFor: "Ask for a Napa Valley or Sonoma Cabernet, $30-50", min: 30, max: 50, producers: ["Caymus", "Silver Oak", "Jordan"] },
-        { desc: "Premium Napa Cabernet", askFor: "Ask for a premium Napa Cabernet from a single vineyard", min: 75, max: 150, producers: ["Opus One", "Stag's Leap", "Chateau Montelena"] }
+        { desc: "Napa or Sonoma Cabernet", askFor: "Ask for a Napa Valley or Sonoma Cabernet — big and bold", producers: ["Caymus", "Silver Oak", "Jordan"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -509,8 +485,7 @@ async function seedJourneys() {
       // Chapter 2: Pinot Noir
       const pinotOptions = createWineOptions(
         { desc: "California or Oregon Pinot under $20", askFor: "Ask for a California or Oregon Pinot Noir under $20", min: 12, max: 20, producers: ["Meiomi", "A to Z", "La Crema"] },
-        { desc: "Oregon Willamette or Russian River", askFor: "Ask for an Oregon Willamette Valley or Sonoma Russian River Pinot, $25-45", min: 25, max: 45, producers: ["Domaine Drouhin Oregon", "Williams Selyem"] },
-        { desc: "Single Vineyard Pinot", askFor: "Ask for a single vineyard Pinot Noir from Oregon or California", min: 50, max: 80, producers: ["Beaux Frères", "Kosta Browne"] }
+        { desc: "Oregon Willamette or Russian River", askFor: "Ask for an Oregon Willamette or Sonoma Russian River Pinot", producers: ["Domaine Drouhin Oregon", "Williams Selyem"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -539,8 +514,7 @@ async function seedJourneys() {
       // Chapter 3: Chardonnay
       const chardOptions = createWineOptions(
         { desc: "California Chardonnay under $15", askFor: "Ask for a California Chardonnay under $15", min: 10, max: 15, producers: ["Kendall-Jackson", "La Crema", "Rombauer"] },
-        { desc: "Sonoma or Central Coast Chardonnay", askFor: "Ask for a Sonoma or Central Coast Chardonnay, $20-35", min: 20, max: 35, producers: ["Cakebread", "Mer Soleil"] },
-        { desc: "Premium California Chardonnay", askFor: "Ask for a premium California Chardonnay (Napa or Sonoma)", min: 40, max: 70, producers: ["Kistler", "Peter Michael"] }
+        { desc: "Sonoma or Central Coast Chardonnay", askFor: "Ask for a Sonoma or Central Coast Chardonnay — richer and more complex", producers: ["Cakebread", "Mer Soleil"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -569,8 +543,7 @@ async function seedJourneys() {
       // Chapter 4: Sauvignon Blanc
       const sbOptions = createWineOptions(
         { desc: "New Zealand Sauvignon Blanc under $15", askFor: "Ask for a Marlborough Sauvignon Blanc under $15", min: 10, max: 15, producers: ["Oyster Bay", "Kim Crawford", "Cloudy Bay"] },
-        { desc: "Premium NZ or California SB", askFor: "Ask for a premium NZ Sauvignon Blanc or California, $18-30", min: 18, max: 30, producers: ["Dog Point", "Cloudy Bay Te Koko"] },
-        { desc: "Single Vineyard SB", askFor: "Ask for a single vineyard Marlborough Sauvignon Blanc", min: 30, max: 50, producers: ["Clos Henri", "Greywacke"] }
+        { desc: "Premium NZ or California SB", askFor: "Ask for a premium NZ Sauvignon Blanc or California version", producers: ["Dog Point", "Cloudy Bay Te Koko"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -621,7 +594,7 @@ async function seedJourneys() {
       // Chapter 1: Entry Oregon Pinot
       const oregonEntryOptions = createWineOptions(
         { desc: "Oregon Pinot Noir under $20", askFor: "Ask for any Oregon Pinot Noir under $20", min: 15, max: 20, producers: ["A to Z", "Erath", "King Estate"] },
-        { desc: "Oregon AVA Pinot", askFor: "Ask for an Oregon Pinot with an AVA designation, $25-35", min: 25, max: 35, producers: ["Willamette Valley Vineyards", "Ponzi"] }
+        { desc: "Oregon AVA Pinot", askFor: "Ask for an Oregon Pinot with an AVA designation", producers: ["Willamette Valley Vineyards", "Ponzi"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -649,9 +622,8 @@ async function seedJourneys() {
 
       // Chapter 2: Willamette Valley
       const willametteOptions = createWineOptions(
-        { desc: "Willamette Valley Pinot", askFor: "Ask specifically for Willamette Valley Pinot Noir, $25-40", min: 25, max: 40, producers: ["Sokol Blosser", "Domaine Serene", "Rex Hill"] },
-        { desc: "Premium Willamette", askFor: "Ask for a premium Willamette Valley producer, $45-65", min: 45, max: 65, producers: ["Adelsheim", "Ken Wright"] },
-        { desc: "Top Willamette Producer", askFor: "Ask for a top Willamette producer if you want to splurge", min: 70, max: 100, producers: ["Domaine Drouhin Oregon", "Beaux Frères"] }
+        { desc: "Willamette Valley Pinot", askFor: "Ask specifically for Willamette Valley Pinot Noir under $25", min: 20, max: 25, producers: ["Sokol Blosser", "Rex Hill"] },
+        { desc: "Premium Willamette", askFor: "Ask for a premium Willamette Valley producer — world-class Pinot", producers: ["Adelsheim", "Ken Wright", "Domaine Serene"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -679,9 +651,8 @@ async function seedJourneys() {
 
       // Chapter 3: Sub-AVA (Dundee Hills, Eola-Amity, etc.)
       const subAvaOptions = createWineOptions(
-        { desc: "Named Sub-AVA Pinot", askFor: "Ask for a Pinot from Dundee Hills, Eola-Amity, or Ribbon Ridge, $35-55", min: 35, max: 55, producers: ["Archery Summit", "Evening Land", "Cristom"] },
-        { desc: "Premium Sub-AVA Pinot", askFor: "Ask for a premium sub-AVA specific Pinot, $60-85", min: 60, max: 85, producers: ["Domaine Serene (Evenstad)", "White Rose"] },
-        { desc: "Single Vineyard from Sub-AVA", askFor: "Ask for a single vineyard from a specific sub-AVA", min: 85, max: 120, producers: ["Shea Wine Cellars", "Patricia Green Cellars"] }
+        { desc: "Named Sub-AVA Pinot", askFor: "Ask for a Pinot from Dundee Hills, Eola-Amity, or Ribbon Ridge", min: 20, max: 25, producers: ["Archery Summit", "Evening Land", "Cristom"] },
+        { desc: "Premium Sub-AVA Pinot", askFor: "Ask for a premium sub-AVA specific Pinot — taste the terroir", producers: ["Domaine Serene (Evenstad)", "White Rose"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -709,9 +680,8 @@ async function seedJourneys() {
 
       // Chapter 4: Single Vineyard Premium
       const premiumOptions = createWineOptions(
-        { desc: "Single Vineyard Oregon Pinot", askFor: "Ask for a single vineyard Oregon Pinot Noir, $50-80", min: 50, max: 80, producers: ["Ken Wright Cellars (various vineyards)", "Bergström"] },
-        { desc: "Premium Single Vineyard", askFor: "Ask for a premium single vineyard from a top producer, $80-120", min: 80, max: 120, producers: ["Beaux Frères (Beaux Frères Vineyard)", "Domaine Drouhin (Louise Drouhin)"] },
-        { desc: "Collector's Oregon Pinot", askFor: "Ask for a collector-grade Oregon Pinot if available", min: 120, max: 200, producers: ["Evening Land (Seven Springs)", "Antica Terra"] }
+        { desc: "Single Vineyard Oregon Pinot", askFor: "Ask for a single vineyard Oregon Pinot Noir", min: 20, max: 25, producers: ["Ken Wright Cellars (various vineyards)", "Bergström"] },
+        { desc: "Premium Single Vineyard", askFor: "Ask for a premium single vineyard from a top producer", producers: ["Beaux Frères (Beaux Frères Vineyard)", "Domaine Drouhin (Louise Drouhin)"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -762,8 +732,7 @@ async function seedJourneys() {
       // Chapter 1: Rioja
       const riojaOptions = createWineOptions(
         { desc: "Rioja Crianza", askFor: "Ask for a Rioja Crianza under $18", min: 12, max: 18, producers: ["Marqués de Cáceres", "CVNE", "Bodegas Muga"] },
-        { desc: "Rioja Reserva", askFor: "Ask for a Rioja Reserva, $20-35", min: 20, max: 35, producers: ["La Rioja Alta", "López de Heredia", "Marqués de Riscal"] },
-        { desc: "Rioja Gran Reserva", askFor: "Ask for a Rioja Gran Reserva for something special", min: 40, max: 70, producers: ["López de Heredia (Viña Tondonia)", "CVNE (Imperial)"] }
+        { desc: "Rioja Reserva", askFor: "Ask for a Rioja Reserva — oak-aged elegance from Spain", producers: ["La Rioja Alta", "López de Heredia", "Marqués de Riscal"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -792,8 +761,7 @@ async function seedJourneys() {
       // Chapter 2: Ribera del Duero
       const riberaOptions = createWineOptions(
         { desc: "Ribera del Duero Roble/Joven", askFor: "Ask for a young Ribera del Duero under $20", min: 14, max: 20, producers: ["Protos", "Pesquera", "Condado de Haza"] },
-        { desc: "Ribera del Duero Crianza", askFor: "Ask for a Ribera del Duero Crianza, $25-45", min: 25, max: 45, producers: ["Pago de Carraovejas", "Emilio Moro"] },
-        { desc: "Premium Ribera", askFor: "Ask for a premium Ribera del Duero like Pingus or Vega Sicilia", min: 60, max: 150, producers: ["Vega Sicilia (Valbuena)", "Dominio de Pingus (Flor de Pingus)"] }
+        { desc: "Ribera del Duero Crianza", askFor: "Ask for a Ribera del Duero Crianza — power and elegance", producers: ["Pago de Carraovejas", "Emilio Moro"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -821,9 +789,8 @@ async function seedJourneys() {
 
       // Chapter 3: Priorat
       const prioratOptions = createWineOptions(
-        { desc: "Entry Priorat", askFor: "Ask for an entry-level Priorat or Vi de Vila, $20-30", min: 20, max: 30, producers: ["Clos Mogador (Manyetes)", "Torres (Salmos)", "Alvaro Palacios (Camins)"] },
-        { desc: "Priorat DOQ", askFor: "Ask for a Priorat DOQ, $35-55", min: 35, max: 55, producers: ["Clos Figueras", "Mas Doix", "Terroir al Limit"] },
-        { desc: "Premium Priorat", askFor: "Ask for L'Ermita, Clos Mogador, or similar", min: 70, max: 200, producers: ["Alvaro Palacios (L'Ermita)", "Clos Mogador", "Clos Erasmus"] }
+        { desc: "Entry Priorat", askFor: "Ask for an entry-level Priorat or Vi de Vila under $25", min: 20, max: 25, producers: ["Clos Mogador (Manyetes)", "Torres (Salmos)", "Alvaro Palacios (Camins)"] },
+        { desc: "Priorat DOQ", askFor: "Ask for a Priorat DOQ — mineral-rich and intense", producers: ["Clos Figueras", "Mas Doix", "Terroir al Limit"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -852,8 +819,7 @@ async function seedJourneys() {
       // Chapter 4: Garnacha
       const garnachaOptions = createWineOptions(
         { desc: "Campo de Borja or Calatayud Garnacha", askFor: "Ask for a Garnacha from Aragon under $15", min: 10, max: 15, producers: ["Borsao", "El Escocés Volante", "Corona de Aragón"] },
-        { desc: "Old Vine Garnacha", askFor: "Ask for an old vine Garnacha, $18-30", min: 18, max: 30, producers: ["Alto Moncayo", "Bodegas San Alejandro (Las Rocas)"] },
-        { desc: "Premium Garnacha", askFor: "Ask for a premium single vineyard Garnacha", min: 35, max: 60, producers: ["Comando G", "4 Monos"] }
+        { desc: "Old Vine Garnacha", askFor: "Ask for an old vine Garnacha — concentrated and spicy", producers: ["Alto Moncayo", "Bodegas San Alejandro (Las Rocas)"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -904,8 +870,7 @@ async function seedJourneys() {
       // Chapter 1: Argentine Malbec
       const malbecOptions = createWineOptions(
         { desc: "Mendoza Malbec under $15", askFor: "Ask for a Mendoza Malbec under $15", min: 10, max: 15, producers: ["Alamos", "Trivento", "Trapiche"] },
-        { desc: "High Altitude Malbec", askFor: "Ask for a high altitude Malbec from Uco Valley, $20-35", min: 20, max: 35, producers: ["Catena", "Zuccardi", "Achaval Ferrer"] },
-        { desc: "Premium Argentine Malbec", askFor: "Ask for a premium single vineyard Malbec", min: 45, max: 80, producers: ["Catena Zapata (Adrianna)", "Cobos", "Cheval des Andes"] }
+        { desc: "High Altitude Malbec", askFor: "Ask for a high altitude Malbec from Uco Valley", producers: ["Catena", "Zuccardi", "Achaval Ferrer"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -934,8 +899,7 @@ async function seedJourneys() {
       // Chapter 2: Australian Shiraz
       const shirazOptions = createWineOptions(
         { desc: "Australian Shiraz under $18", askFor: "Ask for an Australian Shiraz under $18", min: 12, max: 18, producers: ["Penfolds Koonunga Hill", "Jacob's Creek", "19 Crimes"] },
-        { desc: "Barossa or McLaren Vale Shiraz", askFor: "Ask for a Barossa Valley or McLaren Vale Shiraz, $25-45", min: 25, max: 45, producers: ["d'Arenberg", "Torbreck", "Two Hands"] },
-        { desc: "Premium Australian Shiraz", askFor: "Ask for a premium Australian Shiraz if you want to splurge", min: 50, max: 100, producers: ["Penfolds (Bin 389, Bin 150)", "Henschke", "Clarendon Hills"] }
+        { desc: "Barossa or McLaren Vale Shiraz", askFor: "Ask for a Barossa Valley or McLaren Vale Shiraz — bold and peppery", producers: ["d'Arenberg", "Torbreck", "Two Hands"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -964,8 +928,7 @@ async function seedJourneys() {
       // Chapter 3: California Zinfandel
       const zinfandelOptions = createWineOptions(
         { desc: "California Zinfandel under $18", askFor: "Ask for a California Zinfandel under $18", min: 12, max: 18, producers: ["Ravenswood", "Seghesio", "Bogle Old Vine"] },
-        { desc: "Sonoma or Lodi Old Vine Zin", askFor: "Ask for an old vine Zinfandel from Sonoma or Lodi, $22-40", min: 22, max: 40, producers: ["Ridge", "Turley", "Robert Biale"] },
-        { desc: "Premium Single Vineyard Zin", askFor: "Ask for a single vineyard old vine Zinfandel", min: 45, max: 75, producers: ["Ridge (Geyserville, Lytton Springs)", "Turley (single vineyard)"] }
+        { desc: "Old Vine Zinfandel", askFor: "Ask for an old vine Zinfandel from Sonoma or Lodi", producers: ["Ridge", "Turley", "Robert Biale"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -994,8 +957,7 @@ async function seedJourneys() {
       // Chapter 4: Petite Sirah
       const petiteSirahOptions = createWineOptions(
         { desc: "California Petite Sirah under $20", askFor: "Ask for a California Petite Sirah under $20", min: 14, max: 20, producers: ["Bogle", "Concannon", "Michael David"] },
-        { desc: "Lodi or Paso Robles PS", askFor: "Ask for a Lodi or Paso Robles Petite Sirah, $25-40", min: 25, max: 40, producers: ["Turley", "Stags' Leap Winery"] },
-        { desc: "Premium Petite Sirah", askFor: "Ask for a premium or old vine Petite Sirah", min: 45, max: 70, producers: ["Turley (Hayne, Pesenti)", "Foppiano"] }
+        { desc: "Lodi or Paso Robles Petite Sirah", askFor: "Ask for a Lodi or Paso Robles Petite Sirah — dark and powerful", producers: ["Turley", "Stags' Leap Winery"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -1046,8 +1008,7 @@ async function seedJourneys() {
       // Chapter 1: Riesling
       const rieslingOptions = createWineOptions(
         { desc: "German Kabinett Riesling", askFor: "Ask for a German Kabinett Riesling under $20", min: 14, max: 20, producers: ["Dr. Loosen", "Selbach-Oster", "Joh. Jos. Prüm"] },
-        { desc: "Alsace or German Spätlese", askFor: "Ask for an Alsace Riesling or German Spätlese, $22-40", min: 22, max: 40, producers: ["Trimbach", "Domaine Weinbach", "Fritz Haag"] },
-        { desc: "Grand Cru Riesling", askFor: "Ask for an Alsace Grand Cru or German GG Riesling", min: 45, max: 80, producers: ["Trimbach (Clos Ste Hune)", "Dönnhoff (GG)", "Keller"] }
+        { desc: "Alsace or German Spätlese", askFor: "Ask for an Alsace Riesling or German Spätlese — complex and age-worthy", producers: ["Trimbach", "Domaine Weinbach", "Fritz Haag"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -1076,8 +1037,7 @@ async function seedJourneys() {
       // Chapter 2: Grüner Veltliner
       const grunerOptions = createWineOptions(
         { desc: "Austrian Grüner Veltliner under $18", askFor: "Ask for an Austrian Grüner Veltliner under $18", min: 12, max: 18, producers: ["Laurenz V", "Hugl", "Loimer"] },
-        { desc: "Wachau or Kremstal Grüner", askFor: "Ask for a Wachau or Kremstal Grüner, $22-38", min: 22, max: 38, producers: ["F.X. Pichler", "Hirtzberger", "Nikolaihof"] },
-        { desc: "Premium Smaragd Grüner", askFor: "Ask for a Smaragd or Reserve Grüner Veltliner", min: 40, max: 70, producers: ["Knoll", "Prager", "Rudi Pichler"] }
+        { desc: "Wachau or Kremstal Grüner", askFor: "Ask for a Wachau or Kremstal Grüner — peppery and complex", producers: ["F.X. Pichler", "Hirtzberger", "Nikolaihof"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -1106,8 +1066,7 @@ async function seedJourneys() {
       // Chapter 3: Chenin Blanc
       const cheninOptions = createWineOptions(
         { desc: "South African Chenin Blanc under $15", askFor: "Ask for a South African Chenin Blanc under $15", min: 10, max: 15, producers: ["Ken Forrester", "Spier", "Mullineux"] },
-        { desc: "Loire Vouvray or SA Premium", askFor: "Ask for a Vouvray or premium South African Chenin, $20-35", min: 20, max: 35, producers: ["Domaine Huet", "Champalou", "Raats"] },
-        { desc: "Premium Loire Chenin", askFor: "Ask for a top Loire Chenin (Savennières, aged Vouvray)", min: 40, max: 70, producers: ["Nicolas Joly", "Domaine des Baumard", "François Chidaine"] }
+        { desc: "Loire Vouvray or SA Premium", askFor: "Ask for a Vouvray or premium South African Chenin", producers: ["Domaine Huet", "Champalou", "Raats"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -1136,8 +1095,7 @@ async function seedJourneys() {
       // Chapter 4: Albariño
       const albarinoOptions = createWineOptions(
         { desc: "Rías Baixas Albariño under $18", askFor: "Ask for a Rías Baixas Albariño under $18", min: 12, max: 18, producers: ["Martín Códax", "Burgáns", "Pazo de Señoráns"] },
-        { desc: "Premium Rías Baixas", askFor: "Ask for a premium or single vineyard Albariño, $22-35", min: 22, max: 35, producers: ["Do Ferreiro", "Zárate", "Forjas del Salnés"] },
-        { desc: "Top Producer Albariño", askFor: "Ask for a top producer aged or special cuvée Albariño", min: 38, max: 60, producers: ["Raúl Pérez (Sketch)", "Zárate (El Palomar)"] }
+        { desc: "Premium Rías Baixas Albariño", askFor: "Ask for a premium or single vineyard Albariño — coastal and saline", producers: ["Do Ferreiro", "Zárate", "Forjas del Salnés"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -1188,7 +1146,7 @@ async function seedJourneys() {
       // Chapter 1: Match Weight with Weight
       const weightOptions = createWineOptions(
         { desc: "Light white or rosé", askFor: "Ask for a Pinot Grigio, Vinho Verde, or dry rosé under $15", min: 10, max: 15, producers: ["Santa Margherita", "Casal Garcia", "Whispering Angel"] },
-        { desc: "Medium-bodied option", askFor: "Ask for a Chablis, unoaked Chardonnay, or Côtes du Rhône", min: 18, max: 30, producers: ["Louis Latour (Chablis)", "E. Guigal (CdR)"] }
+        { desc: "Medium-bodied option", askFor: "Ask for a Chablis, unoaked Chardonnay, or Côtes du Rhône", producers: ["Louis Latour (Chablis)", "E. Guigal (CdR)"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -1217,7 +1175,7 @@ async function seedJourneys() {
       // Chapter 2: Acid Cuts Fat
       const acidOptions = createWineOptions(
         { desc: "High-acid white", askFor: "Ask for a Sancerre, Muscadet, or Cava under $20", min: 12, max: 20, producers: ["Henri Bourgeois", "Muscadet Sèvre et Maine", "Freixenet"] },
-        { desc: "High-acid red", askFor: "Ask for a Chianti, Barbera, or Pinot Noir", min: 15, max: 30, producers: ["Antinori", "Michele Chiarlo (Barbera)", "La Crema"] }
+        { desc: "High-acid red", askFor: "Ask for a Chianti, Barbera, or Pinot Noir — acid cuts fat beautifully", producers: ["Antinori", "Michele Chiarlo (Barbera)", "La Crema"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -1246,7 +1204,7 @@ async function seedJourneys() {
       // Chapter 3: Tannins and Protein
       const tanninOptions = createWineOptions(
         { desc: "Tannic red wine", askFor: "Ask for a Cabernet Sauvignon, Malbec, or Barolo under $25", min: 15, max: 25, producers: ["Robert Mondavi", "Catena", "Pio Cesare (Langhe)"] },
-        { desc: "Premium tannic red", askFor: "Ask for a Napa Cabernet or Barolo", min: 30, max: 55, producers: ["Caymus", "Silver Oak", "Fontanafredda"] }
+        { desc: "Premium tannic red", askFor: "Ask for a Napa Cabernet or Barolo — tannins meet protein", producers: ["Caymus", "Silver Oak", "Fontanafredda"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)
@@ -1275,7 +1233,7 @@ async function seedJourneys() {
       // Chapter 4: Sweet with Spicy
       const sweetOptions = createWineOptions(
         { desc: "Off-dry wine", askFor: "Ask for an off-dry Riesling, Gewürztraminer, or Moscato under $18", min: 10, max: 18, producers: ["Dr. Loosen", "Hugel (Gentil)", "La Spinetta (Moscato d'Asti)"] },
-        { desc: "Premium off-dry", askFor: "Ask for a Spätlese Riesling or Alsace Gewürztraminer", min: 20, max: 35, producers: ["Selbach-Oster", "Trimbach (Gewürz)"] }
+        { desc: "Premium off-dry", askFor: "Ask for a Spätlese Riesling or Alsace Gewürztraminer — sweetness tames spice", producers: ["Selbach-Oster", "Trimbach (Gewürz)"] }
       );
       await sql`
         INSERT INTO chapters (journey_id, chapter_number, title, description, wine_requirements, learning_objectives, tasting_prompts, completion_criteria, wine_options)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,6 +21,7 @@ import { registerAuthRoutes } from './routes/auth';
 import { registerTastingsRoutes } from './routes/tastings';
 import { registerWinesRoutes } from './routes/wines';
 import { registerJourneyRoutes } from './routes/journeys';
+import { registerPlacesRoutes } from './routes/places';
 import { registerTranscriptionRoutes } from './routes/transcription';
 import { registerSommelierChatRoutes } from './routes/sommelier-chat';
 
@@ -2100,6 +2101,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Register journey routes (Sprint 3)
   registerJourneyRoutes(app);
+
+  // Register places routes (nearby wine shops)
+  registerPlacesRoutes(app);
 
   // Register audio transcription routes
   registerTranscriptionRoutes(app);

--- a/server/routes/journeys.ts
+++ b/server/routes/journeys.ts
@@ -2,6 +2,7 @@ import type { Express } from "express";
 import { storage } from "../storage";
 import { validateWineForChapter, getValidationMessage } from "../services/wineValidation";
 import { generateQuestionsForWine, getFallbackQuestions } from "../services/questionGenerator";
+import { generateShoppingGuide } from "../services/shoppingGuideGenerator";
 import type { WineRecognitionResult, TastingLevel } from "@shared/schema";
 import { requireAuth, requireAdmin } from "./auth";
 import { aiRateLimit } from "../middleware/rateLimiter";
@@ -436,6 +437,44 @@ export function registerJourneyRoutes(app: Express) {
     } catch (error) {
       console.error("Error fetching journeys:", error);
       res.status(500).json({ message: "Internal server error" });
+    }
+  });
+
+  // Generate AI shopping guide (budget/splurge wine options) for a chapter
+  app.post("/api/admin/chapters/:chapterId/generate-shopping-guide", requireAuth, requireAdmin, aiRateLimit, async (req, res) => {
+    try {
+      const chapterId = parseInt(req.params.chapterId);
+
+      if (isNaN(chapterId)) {
+        return res.status(400).json({ message: "Invalid chapter ID" });
+      }
+
+      const chapter = await storage.getChapterById(chapterId);
+      if (!chapter) {
+        return res.status(404).json({ message: "Chapter not found" });
+      }
+
+      const wineRequirements = (chapter as any).wineRequirements || {};
+
+      const result = await generateShoppingGuide(
+        wineRequirements,
+        chapter.title,
+        chapter.description || undefined
+      );
+
+      // Save the generated wine options to the chapter
+      await storage.updateChapter(chapterId, {
+        wineOptions: result.wineOptions
+      });
+
+      res.json({
+        success: true,
+        wineOptions: result.wineOptions,
+        message: "Shopping guide generated and saved"
+      });
+    } catch (error) {
+      console.error("Error generating shopping guide:", error);
+      res.status(500).json({ message: "Failed to generate shopping guide" });
     }
   });
 }

--- a/server/routes/places.ts
+++ b/server/routes/places.ts
@@ -1,0 +1,124 @@
+import type { Express } from "express";
+import { createRateLimit } from "../middleware/rateLimiter";
+
+interface PlaceResult {
+  id: string;
+  name: string;
+  address: string;
+  rating: number | null;
+  ratingCount: number | null;
+  lat: number;
+  lng: number;
+  businessStatus: string;
+}
+
+// Grid-based cache: round coordinates to 2 decimal places (~1.1km), 30-min TTL
+const placesCache = new Map<string, { data: PlaceResult[]; expiresAt: number }>();
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+function getCacheKey(lat: number, lng: number, radius: number): string {
+  // Round to 2 decimal places for grid-based caching
+  const gridLat = Math.round(lat * 100) / 100;
+  const gridLng = Math.round(lng * 100) / 100;
+  return `${gridLat},${gridLng},${radius}`;
+}
+
+function getCached(key: string): PlaceResult[] | null {
+  const entry = placesCache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    placesCache.delete(key);
+    return null;
+  }
+  return entry.data;
+}
+
+function setCache(key: string, data: PlaceResult[]): void {
+  placesCache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+const placesRateLimit = createRateLimit({
+  windowMs: 60 * 1000,
+  maxRequests: 20,
+  message: "Too many requests. Try again in a minute."
+});
+
+export function registerPlacesRoutes(app: Express) {
+  console.log("📍 Registering places endpoints...");
+
+  // Nearby wine shops proxy
+  app.get("/api/wine-shops/nearby", placesRateLimit, async (req, res) => {
+    const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+    if (!apiKey) {
+      return res.status(503).json({ message: "Wine shop search is not configured" });
+    }
+
+    const latitude = parseFloat(req.query.latitude as string);
+    const longitude = parseFloat(req.query.longitude as string);
+    const radius = Math.min(parseInt(req.query.radius as string) || 5000, 50000);
+
+    // Validate coordinates
+    if (isNaN(latitude) || isNaN(longitude) || latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+      return res.status(400).json({ message: "Invalid coordinates" });
+    }
+
+    // Check cache
+    const cacheKey = getCacheKey(latitude, longitude, radius);
+    const cached = getCached(cacheKey);
+    if (cached) {
+      return res.json({ shops: cached, cached: true });
+    }
+
+    try {
+      // Google Places API (New) - searchNearby
+      const response = await fetch("https://places.googleapis.com/v1/places:searchNearby", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Goog-Api-Key": apiKey,
+          "X-Goog-FieldMask": "places.id,places.displayName,places.formattedAddress,places.location,places.rating,places.userRatingCount,places.businessStatus"
+        },
+        body: JSON.stringify({
+          includedTypes: ["liquor_store"],
+          locationRestriction: {
+            circle: {
+              center: { latitude, longitude },
+              radius
+            }
+          },
+          maxResultCount: 10
+        })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error("Google Places API error:", response.status, errorText);
+        return res.status(502).json({ message: "Failed to search for wine shops" });
+      }
+
+      const data = await response.json();
+      const places = data.places || [];
+
+      const shops: PlaceResult[] = places
+        .filter((p: any) => p.businessStatus !== "CLOSED_PERMANENTLY")
+        .map((p: any) => ({
+          id: p.id,
+          name: p.displayName?.text || "Unknown",
+          address: p.formattedAddress || "",
+          rating: p.rating || null,
+          ratingCount: p.userRatingCount || null,
+          lat: p.location?.latitude || 0,
+          lng: p.location?.longitude || 0,
+          businessStatus: p.businessStatus || "OPERATIONAL"
+        }));
+
+      // Cache the result
+      setCache(cacheKey, shops);
+
+      res.json({ shops, cached: false });
+    } catch (error) {
+      console.error("Error fetching nearby wine shops:", error);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  });
+}

--- a/server/services/questionGenerator.ts
+++ b/server/services/questionGenerator.ts
@@ -342,13 +342,14 @@ export async function generateQuestionsForWine(
 
     // Ensure we have all core components represented
     const categories = new Set(questions.map(q => q.category));
-    const requiredCategories: QuestionCategory[] = ['fruit', 'secondary', 'tertiary', 'body', 'acidity', 'tannins', 'overall'];
+    // tannins intentionally excluded — AI decides based on wine type (reds/rosé only)
+    const requiredCategories: QuestionCategory[] = ['fruit', 'secondary', 'tertiary', 'body', 'acidity', 'overall'];
 
     for (const cat of requiredCategories) {
       if (!categories.has(cat)) {
-        // Add fallback question for missing category
-        const fallback = FALLBACK_QUESTIONS.find(q => q.category === cat);
-        if (fallback) {
+        // Add all fallback questions for missing category (notice + rate pair)
+        const fallbacks = FALLBACK_QUESTIONS.filter(q => q.category === cat);
+        for (const fallback of fallbacks) {
           questions.push(fallback);
         }
       }

--- a/server/services/questionGenerator.ts
+++ b/server/services/questionGenerator.ts
@@ -26,7 +26,7 @@ const QuestionOptionSchema = z.object({
 
 const GeneratedQuestionSchema = z.object({
   id: z.string(),
-  category: z.enum(['fruit', 'secondary', 'tertiary', 'body', 'acidity', 'overall']),
+  category: z.enum(['fruit', 'secondary', 'tertiary', 'body', 'acidity', 'tannins', 'overall']),
   questionType: z.enum(['multiple_choice', 'scale', 'text']),
   title: z.string(),
   description: z.string().optional(),
@@ -57,7 +57,7 @@ interface RawGPTQuestion {
   wineContext?: string;
 }
 
-// Fallback questions when AI generation fails - based on 5 core components
+// Fallback questions when AI generation fails - based on 6 core components + overall
 const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
   {
     id: 'fruit-1',
@@ -66,7 +66,7 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
     title: 'How much do you enjoy the fruit flavors you\'re tasting?',
     description: 'Think about berries, citrus, stone fruit, or tropical notes',
     scaleMin: 1,
-    scaleMax: 5,
+    scaleMax: 10,
     scaleLabels: ['Not at all', 'Love them']
   },
   {
@@ -106,7 +106,7 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
     title: 'How do you feel about these secondary notes?',
     description: 'Do they add to your enjoyment or distract from it?',
     scaleMin: 1,
-    scaleMax: 5,
+    scaleMax: 10,
     scaleLabels: ['Dislike them', 'Really enjoy them']
   },
   {
@@ -130,7 +130,7 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
     questionType: 'scale',
     title: 'How do you feel about these oak/aged characteristics?',
     scaleMin: 1,
-    scaleMax: 5,
+    scaleMax: 10,
     scaleLabels: ['Too much', 'Love them']
   },
   {
@@ -138,9 +138,9 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
     category: 'body',
     questionType: 'scale',
     title: 'How does the weight feel in your mouth?',
-    description: 'Think of it like milk - skim milk (light) to whole milk (full)',
+    description: 'Think of it like milk — skim milk (light) to whole milk (full)',
     scaleMin: 1,
-    scaleMax: 5,
+    scaleMax: 10,
     scaleLabels: ['Light body', 'Full body']
   },
   {
@@ -149,7 +149,7 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
     questionType: 'scale',
     title: 'Do you enjoy this body style?',
     scaleMin: 1,
-    scaleMax: 5,
+    scaleMax: 10,
     scaleLabels: ['Prefer lighter', 'Prefer fuller']
   },
   {
@@ -159,7 +159,7 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
     title: 'How bright or crisp does this wine taste?',
     description: 'Does it make your mouth water?',
     scaleMin: 1,
-    scaleMax: 5,
+    scaleMax: 10,
     scaleLabels: ['Soft, mellow', 'Bright, crisp']
   },
   {
@@ -168,8 +168,28 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
     questionType: 'scale',
     title: 'Do you enjoy this level of acidity?',
     scaleMin: 1,
-    scaleMax: 5,
+    scaleMax: 10,
     scaleLabels: ['Too much', 'Perfect']
+  },
+  {
+    id: 'tannins-1',
+    category: 'tannins',
+    questionType: 'scale',
+    title: 'How much does this wine dry out your mouth?',
+    description: 'Tannins are that drying, slightly rough feeling on your gums and tongue — like over-steeped tea. Mostly found in red wines.',
+    scaleMin: 1,
+    scaleMax: 10,
+    scaleLabels: ['Silky smooth', 'Grippy and drying']
+  },
+  {
+    id: 'tannins-2',
+    category: 'tannins',
+    questionType: 'scale',
+    title: 'Do you enjoy this level of tannin?',
+    description: 'Some people love that grippy feeling, others prefer smoother wines.',
+    scaleMin: 1,
+    scaleMax: 10,
+    scaleLabels: ['Prefer smoother', 'Love the grip']
   },
   {
     id: 'overall-1',
@@ -181,6 +201,17 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
     scaleLabels: ['Not for me', 'Love it!']
   },
   {
+    id: 'overall-buy-again',
+    category: 'overall',
+    questionType: 'multiple_choice',
+    title: 'Would you buy this wine again?',
+    options: [
+      { id: 'yes', text: 'Yes, definitely!' },
+      { id: 'maybe', text: 'Maybe, at the right price' },
+      { id: 'no', text: 'No, not for me' }
+    ]
+  },
+  {
     id: 'overall-2',
     category: 'overall',
     questionType: 'text',
@@ -190,7 +221,7 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
 ];
 
 /**
- * Generate wine-specific tasting questions focused on 5 core components
+ * Generate wine-specific tasting questions focused on 6 core components
  *
  * @param wineInfo - Recognition result from photographed wine
  * @param chapter - Chapter context for additional guidance
@@ -235,7 +266,7 @@ export async function generateQuestionsForWine(
                   type: 'object',
                   properties: {
                     id: { type: 'string' },
-                    category: { type: 'string', enum: ['fruit', 'secondary', 'tertiary', 'body', 'acidity', 'overall'] },
+                    category: { type: 'string', enum: ['fruit', 'secondary', 'tertiary', 'body', 'acidity', 'tannins', 'overall'] },
                     questionType: { type: 'string', enum: ['multiple_choice', 'scale', 'text'] },
                     title: { type: 'string' },
                     description: { type: 'string' },
@@ -268,7 +299,7 @@ export async function generateQuestionsForWine(
           }
         }
       },
-      max_completion_tokens: 2000
+      max_completion_tokens: userLevel === 'intro' ? 3000 : userLevel === 'intermediate' ? 3500 : 4500
     });
 
     const content = completion.choices[0]?.message?.content;
@@ -295,9 +326,9 @@ export async function generateQuestionsForWine(
         : undefined
     }));
 
-    // Ensure we have all 5 core components represented
+    // Ensure we have all core components represented
     const categories = new Set(questions.map(q => q.category));
-    const requiredCategories: QuestionCategory[] = ['fruit', 'secondary', 'tertiary', 'body', 'acidity', 'overall'];
+    const requiredCategories: QuestionCategory[] = ['fruit', 'secondary', 'tertiary', 'body', 'acidity', 'tannins', 'overall'];
 
     for (const cat of requiredCategories) {
       if (!categories.has(cat)) {
@@ -309,8 +340,8 @@ export async function generateQuestionsForWine(
       }
     }
 
-    // Sort by category order (5 core components + overall)
-    const categoryOrder = { fruit: 0, secondary: 1, tertiary: 2, body: 3, acidity: 4, overall: 5 };
+    // Sort by category order (6 core components + overall)
+    const categoryOrder: Record<string, number> = { fruit: 0, secondary: 1, tertiary: 2, body: 3, acidity: 4, tannins: 5, overall: 6 };
     questions.sort((a, b) => categoryOrder[a.category] - categoryOrder[b.category]);
 
     return questions;
@@ -322,18 +353,19 @@ export async function generateQuestionsForWine(
 }
 
 function getSystemPrompt(userLevel: TastingLevel): string {
-  const questionCount = userLevel === 'intro' ? '6-8' : userLevel === 'intermediate' ? '10-12' : '12-15';
+  const questionCount = userLevel === 'intro' ? '8-10' : userLevel === 'intermediate' ? '10-14' : '14-18';
 
   return `You are a friendly sommelier helping someone discover what they like about wine.
 Your goal is to ask questions that help THEM understand their own preferences.
 
-Focus on these 5 core components (in this order):
+Focus on these 6 core components (in this order):
 1. Fruit flavors - "How much do you enjoy the fruit flavors you're tasting?"
 2. Secondary flavors - herbal, floral, earthy notes
 3. Tertiary flavors - oak, vanilla, aged characteristics
 4. Body - weight and texture in the mouth
 5. Acidity - brightness and crispness
-6. Overall - final rating and impressions
+6. Tannins - dryness and grip in the mouth (REQUIRED for red and rosé wines, SKIP for white and sparkling wines)
+7. Overall - final rating and impressions
 
 Generate ${questionCount} questions total.
 
@@ -354,8 +386,10 @@ ${userLevel === 'advanced' ? `- Dive deeper into terroir, winemaking, vintage ch
 Make it interactive and conversational. The goal is to help them understand what they like about this wine, not test their knowledge.
 
 For multiple_choice questions: provide 4-5 options specific to this wine type.
-For scale questions: use 1-5 for characteristics, 1-10 for overall rating.
+For scale questions: ALWAYS use 1-10 scale for ALL characteristics AND overall rating.
 For text questions: use only for final impressions.
+
+IMPORTANT: Always include a "Would you buy this wine again?" question in the overall category (multiple_choice with options: "Yes, definitely!", "Maybe, at the right price", "No, not for me").
 
 CRITICAL: Frame questions around enjoyment and preference, not identification.
 Good: "How much do you enjoy the fruit flavors?"

--- a/server/services/questionGenerator.ts
+++ b/server/services/questionGenerator.ts
@@ -64,24 +64,18 @@ interface RawGPTQuestion {
   preferenceDirection?: 'more' | 'less';
 }
 
-// Fallback questions when AI generation fails - based on 6 core components + overall
+// Fallback questions when AI generation fails — three-beat structure (notice + rate pairs)
+// Covers 5 core traits + overall. Used when OpenAI is unavailable.
 const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
+  // --- FRUIT (notice + rate) ---
   {
-    id: 'fruit-1',
-    category: 'fruit',
-    questionType: 'scale',
-    title: 'How much do you enjoy the fruit flavors you\'re tasting?',
-    description: 'Think about berries, citrus, stone fruit, or tropical notes',
-    scaleMin: 1,
-    scaleMax: 10,
-    scaleLabels: ['Not at all', 'Love them']
-  },
-  {
-    id: 'fruit-2',
+    id: 'fruit-notice',
     category: 'fruit',
     questionType: 'multiple_choice',
-    title: 'What fruit flavors stand out to you?',
-    description: 'Select all that you notice',
+    beatType: 'notice',
+    title: 'What fruit flavors jump out at you?',
+    description: 'Swirl the glass gently and take a sip. Don\'t overthink it — what\'s the first thing that comes to mind?',
+    educationalNote: 'Wine gets its fruit flavors from the grape itself and fermentation. Red wines often show berry and cherry notes, while whites lean toward citrus and stone fruit.',
     options: [
       { id: 'red-berries', text: 'Red berries (cherry, raspberry, strawberry)' },
       { id: 'dark-berries', text: 'Dark berries (blackberry, blueberry, plum)' },
@@ -92,117 +86,127 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
     allowMultiple: true
   },
   {
-    id: 'secondary-1',
-    category: 'secondary',
-    questionType: 'multiple_choice',
-    title: 'Do you notice any herbal, floral, or earthy notes?',
-    description: 'These add complexity to the wine',
-    options: [
-      { id: 'herbal', text: 'Herbal (mint, eucalyptus, bell pepper)' },
-      { id: 'floral', text: 'Floral (rose, violet, honeysuckle)' },
-      { id: 'earthy', text: 'Earthy (mushroom, soil, forest floor)' },
-      { id: 'mineral', text: 'Mineral (wet stones, chalk, slate)' },
-      { id: 'none', text: 'Not really noticing any' }
-    ],
-    allowMultiple: true
-  },
-  {
-    id: 'secondary-2',
-    category: 'secondary',
+    id: 'fruit-rate',
+    category: 'fruit',
     questionType: 'scale',
-    title: 'How do you feel about these secondary notes?',
-    description: 'Do they add to your enjoyment or distract from it?',
+    beatType: 'rate',
+    title: 'How much do you enjoy these fruit flavors?',
+    description: 'Would you want more or less fruit intensity in your next wine?',
+    preferenceDirection: 'more',
     scaleMin: 1,
     scaleMax: 10,
-    scaleLabels: ['Dislike them', 'Really enjoy them']
+    scaleLabels: ['Not my style', 'Love them']
   },
+  // --- BODY (notice + rate) ---
   {
-    id: 'tertiary-1',
-    category: 'tertiary',
-    questionType: 'multiple_choice',
-    title: 'Do you notice any oak, vanilla, or aged characteristics?',
-    description: 'These come from winemaking and aging',
-    options: [
-      { id: 'vanilla', text: 'Vanilla' },
-      { id: 'toast', text: 'Toast or baking spices' },
-      { id: 'smoke', text: 'Smoke or char' },
-      { id: 'leather', text: 'Leather or tobacco' },
-      { id: 'none', text: 'Not noticing these' }
-    ],
-    allowMultiple: true
-  },
-  {
-    id: 'tertiary-2',
-    category: 'tertiary',
-    questionType: 'scale',
-    title: 'How do you feel about these oak/aged characteristics?',
-    scaleMin: 1,
-    scaleMax: 10,
-    scaleLabels: ['Too much', 'Love them']
-  },
-  {
-    id: 'body-1',
+    id: 'body-notice',
     category: 'body',
     questionType: 'scale',
-    title: 'How does the weight feel in your mouth?',
-    description: 'Think of it like milk — skim milk (light) to whole milk (full)',
+    beatType: 'notice',
+    title: 'How heavy does the wine feel in your mouth?',
+    description: 'Think of it like milk: skim milk is light-bodied, whole milk is medium, cream is full-bodied. Swish it around — does it feel light and watery, or thick and rich?',
+    educationalNote: 'This weight is called "body." It comes from alcohol, sugar, and extract in the wine. Full-bodied wines feel richer and coat your mouth more.',
     scaleMin: 1,
     scaleMax: 10,
-    scaleLabels: ['Light body', 'Full body']
+    scaleLabels: ['Light and delicate', 'Full and rich']
   },
   {
-    id: 'body-2',
+    id: 'body-rate',
     category: 'body',
     questionType: 'scale',
+    beatType: 'rate',
     title: 'Do you enjoy this body style?',
+    preferenceDirection: 'more',
     scaleMin: 1,
     scaleMax: 10,
-    scaleLabels: ['Prefer lighter', 'Prefer fuller']
+    scaleLabels: ['Prefer lighter wines', 'Prefer fuller wines']
   },
+  // --- ACIDITY (notice + rate) ---
   {
-    id: 'acidity-1',
+    id: 'acidity-notice',
     category: 'acidity',
     questionType: 'scale',
-    title: 'How bright or crisp does this wine taste?',
-    description: 'Does it make your mouth water?',
+    beatType: 'notice',
+    title: 'How much zing or crispness do you notice?',
+    description: 'Pay attention to whether your mouth waters after you swallow. More watering = more acidity. Think of it like lemon juice — some wines have a lot of that bright, crisp feeling.',
+    educationalNote: 'That bright, mouth-watering sensation is acidity. It\'s what makes wine feel refreshing rather than flat. Higher acidity wines pair beautifully with food.',
     scaleMin: 1,
     scaleMax: 10,
-    scaleLabels: ['Soft, mellow', 'Bright, crisp']
+    scaleLabels: ['Soft and smooth', 'Bright and zingy']
   },
   {
-    id: 'acidity-2',
+    id: 'acidity-rate',
     category: 'acidity',
     questionType: 'scale',
+    beatType: 'rate',
     title: 'Do you enjoy this level of acidity?',
+    preferenceDirection: 'more',
     scaleMin: 1,
     scaleMax: 10,
-    scaleLabels: ['Too much', 'Perfect']
+    scaleLabels: ['Prefer softer wines', 'Love the zing']
   },
+  // --- TANNINS (notice + rate) ---
   {
-    id: 'tannins-1',
+    id: 'tannins-notice',
     category: 'tannins',
     questionType: 'scale',
+    beatType: 'notice',
     title: 'How much does this wine dry out your mouth?',
-    description: 'Tannins are that drying, slightly rough feeling on your gums and tongue — like over-steeped tea. Mostly found in red wines.',
+    description: 'Focus on your gums and the sides of your tongue. Do they feel smooth, or is there a drying, slightly rough sensation — like over-steeped tea?',
+    educationalNote: 'That drying feeling is called tannin — it comes from grape skins, seeds, and sometimes oak barrels. Tannins add structure and help wines age well.',
     scaleMin: 1,
     scaleMax: 10,
     scaleLabels: ['Silky smooth', 'Grippy and drying']
   },
   {
-    id: 'tannins-2',
+    id: 'tannins-rate',
     category: 'tannins',
     questionType: 'scale',
+    beatType: 'rate',
     title: 'Do you enjoy this level of tannin?',
     description: 'Some people love that grippy feeling, others prefer smoother wines.',
+    preferenceDirection: 'more',
     scaleMin: 1,
     scaleMax: 10,
     scaleLabels: ['Prefer smoother', 'Love the grip']
   },
+  // --- AROMA (notice + rate) ---
   {
-    id: 'overall-1',
+    id: 'secondary-notice',
+    category: 'secondary',
+    questionType: 'multiple_choice',
+    beatType: 'notice',
+    title: 'Beyond the fruit, do you notice any other aromas?',
+    description: 'Give the glass another swirl and take a deeper sniff. These "secondary" aromas add complexity — they\'re what make wines interesting.',
+    educationalNote: 'These are called secondary and tertiary aromas. They come from fermentation (floral, herbal notes) and aging (vanilla, toast, leather). They\'re what make each wine unique.',
+    options: [
+      { id: 'herbal', text: 'Herbal (mint, eucalyptus, bell pepper)' },
+      { id: 'floral', text: 'Floral (rose, violet, honeysuckle)' },
+      { id: 'earthy', text: 'Earthy (mushroom, soil, forest floor)' },
+      { id: 'oaky', text: 'Oaky (vanilla, toast, baking spices)' },
+      { id: 'none', text: 'Not really noticing any' }
+    ],
+    allowMultiple: true
+  },
+  {
+    id: 'secondary-rate',
+    category: 'secondary',
+    questionType: 'scale',
+    beatType: 'rate',
+    title: 'How do you feel about these extra aromas?',
+    description: 'Do they add to your enjoyment or distract from the fruit?',
+    preferenceDirection: 'more',
+    scaleMin: 1,
+    scaleMax: 10,
+    scaleLabels: ['Prefer simpler wines', 'Love the complexity']
+  },
+  // --- OVERALL (no beatType — standard ending) ---
+  {
+    id: 'overall-rating',
     category: 'overall',
     questionType: 'scale',
     title: 'Overall, how much do you enjoy this wine?',
+    description: 'Think about the full experience — the smell, the taste, the aftertaste. Would you be happy if someone poured you another glass?',
     scaleMin: 1,
     scaleMax: 10,
     scaleLabels: ['Not for me', 'Love it!']
@@ -219,11 +223,11 @@ const FALLBACK_QUESTIONS: GeneratedQuestion[] = [
     ]
   },
   {
-    id: 'overall-2',
+    id: 'overall-notes',
     category: 'overall',
     questionType: 'text',
-    title: 'What stood out to you most about this wine?',
-    description: 'Share what you liked or didn\'t like'
+    title: 'Any thoughts you want to remember about this wine?',
+    description: 'What stood out? What would you tell a friend about it?'
   }
 ];
 
@@ -363,47 +367,73 @@ export async function generateQuestionsForWine(
 }
 
 function getSystemPrompt(userLevel: TastingLevel): string {
-  const questionCount = userLevel === 'intro' ? '8-10' : userLevel === 'intermediate' ? '10-14' : '14-18';
+  const traitCount = userLevel === 'intro' ? 5 : userLevel === 'intermediate' ? 6 : 8;
 
   return `You are a friendly sommelier helping someone discover what they like about wine.
-Your goal is to ask questions that help THEM understand their own preferences.
+Your goal is to ask questions that help THEM understand their own preferences through a "notice → learn → rate" pattern.
 
-Focus on these 6 core components (in this order):
-1. Fruit flavors - "How much do you enjoy the fruit flavors you're tasting?"
-2. Secondary flavors - herbal, floral, earthy notes
-3. Tertiary flavors - oak, vanilla, aged characteristics
-4. Body - weight and texture in the mouth
-5. Acidity - brightness and crispness
-6. Tannins - dryness and grip in the mouth (REQUIRED for red and rosé wines, SKIP for white and sparkling wines)
-7. Overall - final rating and impressions
+## Three-Beat Question Structure
 
-Generate ${questionCount} questions total.
+For each sensory characteristic you choose, generate a PAIRED set of two questions:
 
-For ${userLevel} users:
-${userLevel === 'intro' ? `- Keep questions simple and approachable. Use everyday language.
-- Provide helpful descriptions for each option.
-- Focus on "do you like this?" rather than "what is this?"
-- Avoid wine jargon - use comparisons like "like skim milk vs whole milk" for body` : ''}
-${userLevel === 'intermediate' ? `- Can use some wine terminology.
-- Ask about specific flavor notes.
-- Include questions about why they like/dislike certain characteristics.
-- Start introducing regional characteristics.` : ''}
-${userLevel === 'advanced' ? `- Dive deeper into terroir, winemaking, vintage characteristics.
-- Include nuanced distinctions.
-- Ask about balance, complexity, and aging potential.
-- Challenge them to identify specific characteristics.` : ''}
+1. **Notice question** (beatType: "notice"): Guide the user to observe something specific.
+   - Include an "educationalNote" field: 1-2 sentences explaining what they just noticed, shown AFTER they answer.
+   - Example question: "Does this wine make your mouth feel dry or smooth?"
+   - Example educationalNote: "That dryness is called tannin — it comes from grape skins and adds structure to the wine."
 
-Make it interactive and conversational. The goal is to help them understand what they like about this wine, not test their knowledge.
+2. **Rate question** (beatType: "rate"): Ask if they enjoyed that characteristic and whether they'd want more or less.
+   - Include "preferenceDirection" field: "more" if high score means they want more of it, "less" if high means they want less.
+   - Example: "Did you enjoy that feeling? Would you want more or less tannin in your next wine?"
 
-For multiple_choice questions: provide 4-5 options specific to this wine type.
-For scale questions: ALWAYS use 1-10 scale for ALL characteristics AND overall rating.
-For text questions: use only for final impressions.
+## Trait Selection
 
-IMPORTANT: Always include a "Would you buy this wine again?" question in the overall category (multiple_choice with options: "Yes, definitely!", "Maybe, at the right price", "No, not for me").
+Pick the ${traitCount} most interesting/relevant characteristics for THIS specific wine. Choose from:
+- fruit, secondary, tertiary, body, acidity, tannins (tannins REQUIRED for red/rosé, SKIP for white/sparkling)
 
-CRITICAL: Frame questions around enjoyment and preference, not identification.
-Good: "How much do you enjoy the fruit flavors?"
-Bad: "Identify the primary fruit aromas."`;
+Each trait gets exactly 2 questions (notice + rate), so you'll generate ${traitCount * 2} trait questions.
+
+## Required Ending Questions (category: "overall", no beatType needed)
+
+After all trait pairs, ALWAYS include these 3 questions:
+1. Overall rating (scale 1-10, id: "overall-rating")
+2. "Would you buy this wine again?" (multiple_choice, id: "overall-buy-again", options: "Yes, definitely!", "Maybe, at the right price", "No, not for me")
+3. Final notes (text, id: "overall-notes")
+
+## Canonical IDs
+
+Use these exact ID patterns for reliable downstream mapping:
+- \`{trait}-notice\` and \`{trait}-rate\` for each trait (e.g., "tannins-notice", "tannins-rate", "acidity-notice", "acidity-rate")
+- \`overall-rating\`, \`overall-buy-again\`, \`overall-notes\` for ending questions
+
+## Scale Rules
+
+- ALL scale questions use 1-10 range
+- Scale labels should reflect preference, not technical measurement
+- For notice questions: labels describe the spectrum (e.g., "Silky smooth" to "Grippy and drying")
+- For rate questions: labels describe enjoyment (e.g., "Not my style" to "Love it")
+
+## Language Level: ${userLevel}
+
+${userLevel === 'intro' ? `- Use everyday language and sensory comparisons (e.g., "like skim milk vs whole milk" for body)
+- Keep educationalNotes simple and encouraging — no jargon
+- Frame everything as discovery: "Let's find out what you like"
+- Descriptions should include HOW to taste for each characteristic` : ''}
+${userLevel === 'intermediate' ? `- Can use some wine terminology, but explain it briefly
+- educationalNotes can introduce proper terms alongside everyday language
+- Ask about specific flavor notes and regional characteristics
+- Include "why" in rate questions: "Why did you enjoy/not enjoy this?"` : ''}
+${userLevel === 'advanced' ? `- Use wine terminology freely — the user knows it
+- educationalNotes can discuss terroir, winemaking techniques, vintage influence
+- Explore nuance: balance, complexity, aging potential, finish length
+- Rate questions can ask about context: "Would you pair this with food or drink it on its own?"` : ''}
+
+## Question Types
+
+- multiple_choice: provide 4-5 options specific to this wine type
+- scale: ALWAYS 1-10 range
+- text: use only for overall-notes
+
+CRITICAL: This is preference discovery, not a quiz. Never ask "identify" or "name" — always ask "do you notice" and "do you enjoy."`;
 }
 
 function getUserPrompt(wineInfo: WineRecognitionResult, chapter?: Chapter, userLevel?: TastingLevel): string {
@@ -417,16 +447,24 @@ function getUserPrompt(wineInfo: WineRecognitionResult, chapter?: Chapter, userL
   });
   const varietal = sanitized.grapeVariety;
 
-  let prompt = `Generate tasting questions for this wine:
+  // Determine wine type for tannins guidance
+  const isRed = wineInfo.grapeVarieties?.some(g => {
+    const lower = g.toLowerCase();
+    return ['cabernet', 'merlot', 'pinot noir', 'syrah', 'shiraz', 'malbec', 'sangiovese',
+            'nebbiolo', 'tempranillo', 'grenache', 'zinfandel', 'barbera', 'mourvèdre',
+            'primitivo', 'petite sirah', 'carmenere', 'tannat', 'gamay', 'pinotage'].some(r => lower.includes(r));
+  });
+
+  let prompt = `Generate three-beat tasting questions for this wine:
 
 Wine: ${sanitized.name}
 Varietal: ${varietal}
 Region: ${sanitized.region}
+Wine Type: ${isRed ? 'Red' : 'White/Other'} (${isRed ? 'include tannins trait' : 'skip tannins trait'})
 ${sanitized.vintage !== 'NV' ? `Vintage: ${sanitized.vintage}` : ''}
 ${sanitized.producer ? `Producer: ${sanitized.producer}` : ''}`;
 
   if (chapter) {
-    // Sanitize chapter content as well (could be user-generated)
     const chapterTitle = sanitizeForPrompt(chapter.title, 100);
     const chapterDesc = sanitizeForPrompt(chapter.description, 200);
     prompt += `
@@ -436,46 +474,44 @@ Chapter: ${chapterTitle}
 ${chapterDesc ? `Description: ${chapterDesc}` : ''}`;
   }
 
-  // Add varietal-specific guidance (using sanitized varietal)
+  // Add varietal-specific trait suggestions
   prompt += `
 
-Include 2-3 questions specific to ${varietal} characteristics:`;
+For ${varietal}, prioritize these traits in your notice+rate pairs:`;
 
   const varietalLower = varietal.toLowerCase();
   if (varietalLower.includes('sangiovese') || varietalLower.includes('chianti')) {
     prompt += `
-- For Sangiovese, ask about cherry notes, tomato-like acidity, and earthy characteristics.`;
+- Cherry/red fruit notes (fruit), tomato-like acidity (acidity), earthy characteristics (secondary), tannin structure (tannins)`;
   } else if (varietalLower.includes('pinot noir')) {
     prompt += `
-- For Pinot Noir, ask about red fruit vs. earth balance, mushroom/forest notes.`;
+- Red fruit vs earth balance (fruit + secondary), mushroom/forest notes (tertiary), silky tannins (tannins), acidity (acidity)`;
   } else if (varietalLower.includes('cabernet')) {
     prompt += `
-- For Cabernet, ask about dark fruit intensity, green/herbal notes, oak influence.`;
+- Dark fruit intensity (fruit), green/herbal notes (secondary), oak influence (tertiary), tannin grip (tannins), body (body)`;
   } else if (varietalLower.includes('chardonnay')) {
     prompt += `
-- For Chardonnay, ask about citrus vs. tropical fruit, oak/butter influence, minerality.`;
+- Citrus vs tropical fruit (fruit), oak/butter influence (tertiary), minerality (secondary), body (body), acidity (acidity)`;
   } else if (varietalLower.includes('sauvignon blanc')) {
     prompt += `
-- For Sauvignon Blanc, ask about citrus, grassy notes, and minerality.`;
+- Citrus and tropical notes (fruit), grassy/herbal character (secondary), minerality (secondary), acidity (acidity)`;
   } else if (varietalLower.includes('riesling')) {
     prompt += `
-- For Riesling, ask about sweetness level, petrol notes, and stone fruit.`;
+- Sweetness perception (fruit), stone fruit notes (fruit), petrol/mineral (secondary), acidity (acidity)`;
   } else {
     prompt += `
-- Ask about characteristics typical of ${varietal} from ${sanitized.region}.`;
+- Choose the most interesting characteristics of ${varietal} from ${sanitized.region}`;
   }
 
-  // Add region-specific guidance
   if (sanitized.region && sanitized.region !== 'Unknown Region') {
     prompt += `
-
-Include 1-2 questions about what makes ${sanitized.region} wines distinctive.`;
+- Include at least one trait pair that highlights what makes ${sanitized.region} wines distinctive`;
   }
 
   prompt += `
 
-Remember: Focus on what the taster ENJOYS about these characteristics, not just identification.
-Frame questions conversationally: "How do you feel about..." rather than "Identify..."`;
+Remember: Each trait gets exactly 2 questions (notice + rate) with educationalNote on the notice question.
+End with overall-rating, overall-buy-again, and overall-notes.`;
 
   return prompt;
 }

--- a/server/services/questionGenerator.ts
+++ b/server/services/questionGenerator.ts
@@ -35,7 +35,11 @@ const GeneratedQuestionSchema = z.object({
   scaleMin: z.number().optional(),
   scaleMax: z.number().optional(),
   scaleLabels: z.tuple([z.string(), z.string()]).optional(),
-  wineContext: z.string().optional()
+  wineContext: z.string().optional(),
+  // Three-beat loop fields
+  beatType: z.enum(['notice', 'rate']).optional(),
+  educationalNote: z.string().optional(),
+  preferenceDirection: z.enum(['more', 'less']).optional()
 });
 
 const QuestionSetSchema = z.object({
@@ -55,6 +59,9 @@ interface RawGPTQuestion {
   scaleMax?: number;
   scaleLabels?: string[];
   wineContext?: string;
+  beatType?: 'notice' | 'rate';
+  educationalNote?: string;
+  preferenceDirection?: 'more' | 'less';
 }
 
 // Fallback questions when AI generation fails - based on 6 core components + overall
@@ -287,7 +294,10 @@ export async function generateQuestionsForWine(
                     scaleMin: { type: 'number' },
                     scaleMax: { type: 'number' },
                     scaleLabels: { type: 'array', items: { type: 'string' } },
-                    wineContext: { type: 'string' }
+                    wineContext: { type: 'string' },
+                    beatType: { type: 'string', enum: ['notice', 'rate'] },
+                    educationalNote: { type: 'string' },
+                    preferenceDirection: { type: 'string', enum: ['more', 'less'] }
                   },
                   required: ['id', 'category', 'questionType', 'title'],
                   additionalProperties: false

--- a/server/services/shoppingGuideGenerator.ts
+++ b/server/services/shoppingGuideGenerator.ts
@@ -1,0 +1,117 @@
+import { requireOpenAI } from "../lib/openai";
+import type { WineOption } from "@shared/schema";
+
+interface WineRequirements {
+  wineType?: string;
+  region?: string;
+  grapeVariety?: string;
+  anyWine?: boolean;
+}
+
+interface GeneratedShoppingGuide {
+  wineOptions: WineOption[];
+}
+
+/**
+ * Generate budget + splurge wine options with shopping guidance
+ * for a chapter's wine requirements.
+ */
+export async function generateShoppingGuide(
+  wineRequirements: WineRequirements,
+  chapterTitle: string,
+  chapterDescription?: string
+): Promise<GeneratedShoppingGuide> {
+  const openai = requireOpenAI();
+
+  const systemPrompt = `You are a wine shop advisor helping someone find the right bottle for a wine tasting lesson.
+
+Generate TWO wine options for the given wine requirements:
+
+1. **Budget option** (level: "budget"): An accessible, affordable bottle under $25. Include:
+   - description: A short, appealing name for this option (e.g., "Cotes du Ventoux Red")
+   - askFor: What to say at the wine shop (conversational, helpful)
+   - priceRange: { min, max } in USD (max should be ≤ 25)
+   - labelTips: What to look for on the bottle label to identify it
+   - substitutes: 2-3 alternative wines that work if they can't find it
+   - exampleProducers: 2-3 specific producer names
+   - whyThisWine: One sentence on why this is a good budget choice for learning
+
+2. **Splurge option** (level: "splurge"): A premium bottle worth treating yourself to. Include:
+   - description: A short, appealing name (e.g., "Chateauneuf-du-Pape")
+   - askFor: What to say at the wine shop
+   - NO priceRange (omit entirely — the user will see the price in the shop)
+   - labelTips: What to look for on the label
+   - substitutes: 2-3 alternatives
+   - exampleProducers: 2-3 specific producer names
+   - whyThisWine: One sentence on why this is worth the splurge
+
+Be accurate with pricing. The budget option should genuinely be findable under $25.
+Be practical with askFor — write what a real person would say to a shop employee.
+Label tips should describe actual text/imagery found on real bottles.`;
+
+  const userPrompt = `Chapter: ${chapterTitle}
+${chapterDescription ? `Description: ${chapterDescription}` : ''}
+Wine requirements:
+- Type: ${wineRequirements.wineType || 'any'}
+- Region: ${wineRequirements.region || 'any'}
+- Grape: ${wineRequirements.grapeVariety || 'any'}
+
+Generate budget and splurge options as JSON.`;
+
+  const response = await openai.chat.completions.create({
+    model: "gpt-5-mini",
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userPrompt }
+    ],
+    response_format: { type: "json_object" },
+    max_completion_tokens: 1500
+  });
+
+  const content = response.choices[0]?.message?.content;
+  if (!content) {
+    throw new Error("No response from OpenAI");
+  }
+
+  const parsed = JSON.parse(content);
+
+  // Normalize the response — GPT may wrap in different ways
+  const options: WineOption[] = [];
+
+  if (parsed.budget) {
+    options.push({
+      ...parsed.budget,
+      level: 'budget',
+      priceRange: parsed.budget.priceRange
+        ? { ...parsed.budget.priceRange, currency: 'USD' }
+        : { min: 10, max: 25, currency: 'USD' }
+    });
+  }
+
+  if (parsed.splurge) {
+    const { priceRange: _omit, ...splurgeData } = parsed.splurge;
+    options.push({
+      ...splurgeData,
+      level: 'splurge'
+    });
+  }
+
+  // Fallback if GPT used an array format
+  if (options.length === 0 && Array.isArray(parsed.wineOptions)) {
+    for (const opt of parsed.wineOptions) {
+      if (opt.level === 'budget') {
+        options.push({
+          ...opt,
+          priceRange: opt.priceRange
+            ? { ...opt.priceRange, currency: 'USD' }
+            : { min: 10, max: 25, currency: 'USD' }
+        });
+      } else if (opt.level === 'splurge') {
+        const { priceRange: _omit, ...rest } = opt;
+        options.push({ ...rest, level: 'splurge' });
+      }
+    }
+  }
+
+  return { wineOptions: options };
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -773,6 +773,13 @@ export interface TastingResponses {
     wouldBuyAgain?: boolean;
     notes?: string;
   };
+  // Three-beat loop: preference signals from "rate" beats
+  preferences?: {
+    [characteristic: string]: {
+      enjoyment: number; // 1-10: how much they liked this characteristic
+      wantMore: boolean; // would they want more of this in future wines
+    };
+  };
 }
 
 // Wine characteristics cache (avoid repeat GPT-4 calls)
@@ -1090,6 +1097,10 @@ export interface GeneratedQuestion {
   scaleLabels?: [string, string];
   // Wine-specific context
   wineContext?: string; // e.g., "Classic Barolo characteristics include..."
+  // Three-beat loop fields
+  beatType?: 'notice' | 'rate'; // Which beat this question represents (legacy questions omit this)
+  educationalNote?: string; // Shown after user answers a 'notice' beat, before advancing to 'rate'
+  preferenceDirection?: 'more' | 'less'; // For rate beats: what "high" means for preference
 }
 
 // Insert schemas

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1069,7 +1069,7 @@ export interface WineRecognitionResult {
 
 // Generated question structure (follows existing tasting flow)
 // Question categories - the 5 core components + overall
-export type QuestionCategory = 'fruit' | 'secondary' | 'tertiary' | 'body' | 'acidity' | 'overall';
+export type QuestionCategory = 'fruit' | 'secondary' | 'tertiary' | 'body' | 'acidity' | 'tannins' | 'overall';
 
 export interface GeneratedQuestion {
   id: string;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -998,14 +998,16 @@ export interface ChapterShoppingGuide {
   askFor?: string;
 }
 
-// Wine options for flexible journey pricing
+// Wine options for journey chapters — budget (under ~$25) and splurge tiers
 export interface WineOption {
   description: string; // e.g., "Any Oregon Pinot Noir"
   askFor: string; // What to tell the wine shop staff
-  priceRange: PriceRange;
+  priceRange?: PriceRange; // Optional — omit for splurge tier
   exampleProducers?: string[]; // e.g., ["Willamette Valley Vineyards", "A to Z"]
-  level: 'entry' | 'mid' | 'premium'; // Price tier
+  level: 'budget' | 'splurge'; // Two-tier pricing
   whyThisWine?: string; // Optional explanation of fit for learning objective
+  labelTips?: string; // What to look for on the label
+  substitutes?: string[]; // Acceptable alternatives if this wine isn't available
 }
 
 // AI-generated next bottle recommendations

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -770,7 +770,7 @@ export interface TastingResponses {
   };
   overall?: {
     rating?: number;
-    wouldBuyAgain?: boolean;
+    wouldBuyAgain?: boolean | 'yes' | 'maybe' | 'no';
     notes?: string;
   };
   // Three-beat loop: preference signals from "rate" beats


### PR DESCRIPTION
## Summary

Three connected improvements to the Learning Journeys experience:

- **Three-Beat Question Loop** — AI-generated tasting questions now follow a notice→(educational note)→rate pattern that teaches wine vocabulary while building preference profiles. Beginner gets 5 traits, intermediate 6, advanced 8.
- **Dual Wine Recommendations** — Each chapter shows a "Budget" (under $25) and "Splurge" option with rich shopping companion guidance (what to ask, label tips, substitutes, example producers). Users pick per-chapter.
- **Nearby Wine Shops** — Google Places API integration with server-side proxy, browser geolocation, grid-based caching (30-min TTL), and tap-to-open-in-maps.

### Changes by phase

| Phase | Commits | Files |
|-------|---------|-------|
| Phase 0: Data pipeline fixes | `c8bf923` | questionGenerator.ts, schema.ts, SoloTastingSession.tsx |
| Phase 1: Three-beat question loop | `258716a`, `02ea7b4`, `a7ae2a4` | schema.ts, questionGenerator.ts, SoloTastingSession.tsx |
| Phase 2: Budget/splurge wines | `b972235`, `1cf8fd9` | schema.ts, WineOptionCard.tsx, JourneyDetail.tsx, SoloTastingNew.tsx, seed-journeys.ts, shoppingGuideGenerator.ts, journeys.ts |
| Phase 3: Nearby wine shops | `3a07af3` | places.ts, routes.ts, useGeolocation.ts, NearbyWineShops.tsx, JourneyDetail.tsx |

### Key decisions
- **Budget/splurge replaces entry/mid/premium** — simpler mental model, two cards instead of three
- **Splurge has no price shown** — "you'll know the price when you see it"
- **Google Places uses `liquor_store` type** — no `wine_store` type exists in the API
- **Grid-based caching** rounds coords to 2 decimal places (~1.1km) for cache hits across nearby users
- **Wine level selection passed via URL params** — JourneyDetail → SoloTastingNew

### New files
- `server/services/shoppingGuideGenerator.ts` — AI shopping guide generation (gpt-5-mini)
- `server/routes/places.ts` — Google Places API proxy with caching + rate limiting
- `client/src/hooks/useGeolocation.ts` — Browser geolocation hook
- `client/src/components/NearbyWineShops.tsx` — Nearby shops UI component

### Environment
- Requires `GOOGLE_PLACES_API_KEY` env var for nearby shops feature (graceful degradation if missing)

## Test plan

- [ ] Start a beginner journey chapter — verify questions follow notice→rate pattern with educational notes between
- [ ] Check intermediate (6 traits) and advanced (8 traits) question counts
- [ ] Verify fallback questions also follow two-beat structure (disable OpenAI to test)
- [ ] Browse chapters — verify budget/splurge wine cards display correctly
- [ ] Select a wine option → start tasting → verify shopping guide shows for selected option
- [ ] Start tasting without selecting → verify old-style shopping tips show as fallback
- [ ] Click "Find wine shops near you" → grant location → verify shops list appears
- [ ] Deny location permission → verify helpful error message
- [ ] Tap a shop → verify it opens in maps app
- [ ] Verify `npm run check` passes clean
- [ ] Run `npm run db:push` if schema changes need migration

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)