### PR TITLE
feat: integrate group tasting data into taste profile

### DIFF
--- a/client/src/pages/AdminDashboard.tsx
+++ b/client/src/pages/AdminDashboard.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Users, Wine, Map, CalendarDays, Activity, CheckCircle } from 'lucide-react';
+import { Users, Wine, Map, CalendarDays, Activity, CheckCircle, User, UsersRound } from 'lucide-react';
 
 interface EngagementData {
   summary: {
@@ -11,11 +11,15 @@ interface EngagementData {
     totalTastings: number;
     tastingsThisWeek: number;
     tastingsThisMonth: number;
+    soloTastings: number;
+    groupTastings: number;
     onboardingCompletionRate: number;
   };
   recentUsers: Array<{
     email: string;
     createdAt: string;
+    soloTastings: number;
+    groupTastings: number;
     tastingsCompleted: number;
     lastTastingDate: string | null;
     tastingLevel: string;
@@ -116,7 +120,7 @@ export default function AdminDashboard() {
         <StatCard
           title="Total Tastings"
           value={summary.totalTastings}
-          subtitle={`${summary.tastingsThisWeek} this week / ${summary.tastingsThisMonth} this month`}
+          subtitle={`${summary.soloTastings} solo + ${summary.groupTastings} group`}
           icon={Wine}
         />
         <StatCard
@@ -128,7 +132,7 @@ export default function AdminDashboard() {
         <StatCard
           title="Tastings / User"
           value={summary.totalUsers > 0 ? (summary.totalTastings / summary.totalUsers).toFixed(1) : '0'}
-          subtitle="Average tastings per user"
+          subtitle={`${summary.tastingsThisWeek} this week / ${summary.tastingsThisMonth} this month`}
           icon={Activity}
         />
       </div>
@@ -157,7 +161,7 @@ export default function AdminDashboard() {
       {/* Recent Users Table */}
       <Card>
         <CardHeader>
-          <CardTitle>Recent Users</CardTitle>
+          <CardTitle>Users by Activity</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="overflow-x-auto">
@@ -166,8 +170,14 @@ export default function AdminDashboard() {
                 <tr className="border-b text-left">
                   <th className="pb-3 font-medium text-muted-foreground">Email</th>
                   <th className="pb-3 font-medium text-muted-foreground">Signed Up</th>
-                  <th className="pb-3 font-medium text-muted-foreground">Tastings</th>
-                  <th className="pb-3 font-medium text-muted-foreground">Last Tasting</th>
+                  <th className="pb-3 font-medium text-muted-foreground text-center" title="Solo tastings">
+                    <User className="h-3.5 w-3.5 inline" /> Solo
+                  </th>
+                  <th className="pb-3 font-medium text-muted-foreground text-center" title="Group tastings">
+                    <UsersRound className="h-3.5 w-3.5 inline" /> Group
+                  </th>
+                  <th className="pb-3 font-medium text-muted-foreground text-center">Total</th>
+                  <th className="pb-3 font-medium text-muted-foreground">Last Active</th>
                   <th className="pb-3 font-medium text-muted-foreground">Level</th>
                   <th className="pb-3 font-medium text-muted-foreground">Onboarded</th>
                 </tr>
@@ -177,7 +187,9 @@ export default function AdminDashboard() {
                   <tr key={user.email} className="border-b last:border-0">
                     <td className="py-3 font-mono text-xs">{user.email}</td>
                     <td className="py-3">{formatDate(user.createdAt)}</td>
-                    <td className="py-3">{user.tastingsCompleted}</td>
+                    <td className="py-3 text-center">{user.soloTastings}</td>
+                    <td className="py-3 text-center">{user.groupTastings}</td>
+                    <td className="py-3 text-center font-semibold">{user.tastingsCompleted}</td>
                     <td className="py-3">{formatDate(user.lastTastingDate)}</td>
                     <td className="py-3">
                       <Badge variant={levelColor(user.tastingLevel)}>{user.tastingLevel}</Badge>

--- a/client/src/pages/AdminDashboard.tsx
+++ b/client/src/pages/AdminDashboard.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Users, Wine, Map, CalendarDays, Activity, CheckCircle, User, UsersRound } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Users, Wine, Map, CalendarDays, Activity, CheckCircle, User, UsersRound, ChevronDown, ChevronRight, Search } from 'lucide-react';
 
 interface EngagementData {
   summary: {
@@ -37,6 +39,30 @@ interface EngagementData {
   };
 }
 
+interface UserDetail {
+  email: string;
+  soloTastings: Array<{
+    id: number;
+    wine_name: string;
+    wine_type: string | null;
+    wine_region: string | null;
+    tasted_at: string;
+    tasting_mode: string;
+    source: 'solo';
+  }>;
+  groupSessions: Array<{
+    id: string;
+    display_name: string;
+    created_at: string;
+    is_host: boolean;
+    short_code: string;
+    session_status: string;
+    package_name: string | null;
+    responses_count: number;
+    source: 'group';
+  }>;
+}
+
 function StatCard({ title, value, subtitle, icon: Icon }: {
   title: string;
   value: string | number;
@@ -64,6 +90,12 @@ function formatDate(dateStr: string | null) {
   });
 }
 
+function formatDateTime(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit'
+  });
+}
+
 function levelColor(level: string) {
   switch (level) {
     case 'intro': return 'secondary';
@@ -73,7 +105,67 @@ function levelColor(level: string) {
   }
 }
 
+function UserDetailPanel({ email }: { email: string }) {
+  const { data, isLoading, error } = useQuery<UserDetail>({
+    queryKey: ['/api/admin/user', email],
+    queryFn: async () => {
+      const res = await fetch(`/api/admin/user/${encodeURIComponent(email)}`);
+      if (!res.ok) throw new Error('Failed to fetch');
+      return res.json();
+    },
+  });
+
+  if (isLoading) return <div className="px-4 py-3 text-sm text-muted-foreground">Loading...</div>;
+  if (error || !data) return <div className="px-4 py-3 text-sm text-destructive">Failed to load</div>;
+
+  const hasActivity = data.soloTastings.length > 0 || data.groupSessions.length > 0;
+
+  if (!hasActivity) {
+    return <div className="px-4 py-3 text-sm text-muted-foreground">No tasting activity yet.</div>;
+  }
+
+  return (
+    <div className="px-4 py-3 space-y-3">
+      {data.soloTastings.length > 0 && (
+        <div>
+          <p className="text-xs font-medium text-muted-foreground mb-1">Solo Tastings</p>
+          <div className="space-y-1">
+            {data.soloTastings.map((t) => (
+              <div key={t.id} className="flex items-center gap-3 text-xs py-1">
+                <span className="text-muted-foreground w-32">{formatDateTime(t.tasted_at)}</span>
+                <span className="font-medium">{t.wine_name}</span>
+                {t.wine_type && <Badge variant="outline" className="text-[10px] py-0">{t.wine_type}</Badge>}
+                {t.wine_region && <span className="text-muted-foreground">{t.wine_region}</span>}
+                <Badge variant="secondary" className="text-[10px] py-0">{t.tasting_mode}</Badge>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {data.groupSessions.length > 0 && (
+        <div>
+          <p className="text-xs font-medium text-muted-foreground mb-1">Group Sessions</p>
+          <div className="space-y-1">
+            {data.groupSessions.map((s) => (
+              <div key={s.id} className="flex items-center gap-3 text-xs py-1">
+                <span className="text-muted-foreground w-32">{formatDateTime(s.created_at)}</span>
+                <span className="font-medium">{s.package_name || 'Unnamed package'}</span>
+                <Badge variant="outline" className="text-[10px] py-0">{s.short_code}</Badge>
+                {s.is_host && <Badge variant="default" className="text-[10px] py-0">Host</Badge>}
+                <span className="text-muted-foreground">{s.responses_count} responses</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function AdminDashboard() {
+  const [search, setSearch] = useState('');
+  const [expandedEmail, setExpandedEmail] = useState<string | null>(null);
+
   const { data, isLoading, error } = useQuery<EngagementData>({
     queryKey: ['/api/admin/engagement'],
     queryFn: async () => {
@@ -101,6 +193,10 @@ export default function AdminDashboard() {
   }
 
   const { summary, recentUsers, journeys, sessions } = data;
+
+  const filteredUsers = search
+    ? recentUsers.filter(u => u.email.toLowerCase().includes(search.toLowerCase()))
+    : recentUsers;
 
   return (
     <div className="min-h-screen bg-background p-6 max-w-7xl mx-auto">
@@ -158,22 +254,32 @@ export default function AdminDashboard() {
         />
       </div>
 
-      {/* Recent Users Table */}
+      {/* Users Table */}
       <Card>
-        <CardHeader>
-          <CardTitle>Users by Activity</CardTitle>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Users ({filteredUsers.length})</CardTitle>
+          <div className="relative w-64">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Filter by email..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-8"
+            />
+          </div>
         </CardHeader>
         <CardContent>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b text-left">
+                  <th className="pb-3 w-6"></th>
                   <th className="pb-3 font-medium text-muted-foreground">Email</th>
                   <th className="pb-3 font-medium text-muted-foreground">Signed Up</th>
-                  <th className="pb-3 font-medium text-muted-foreground text-center" title="Solo tastings">
+                  <th className="pb-3 font-medium text-muted-foreground text-center">
                     <User className="h-3.5 w-3.5 inline" /> Solo
                   </th>
-                  <th className="pb-3 font-medium text-muted-foreground text-center" title="Group tastings">
+                  <th className="pb-3 font-medium text-muted-foreground text-center">
                     <UsersRound className="h-3.5 w-3.5 inline" /> Group
                   </th>
                   <th className="pb-3 font-medium text-muted-foreground text-center">Total</th>
@@ -183,20 +289,41 @@ export default function AdminDashboard() {
                 </tr>
               </thead>
               <tbody>
-                {recentUsers.map((user) => (
-                  <tr key={user.email} className="border-b last:border-0">
-                    <td className="py-3 font-mono text-xs">{user.email}</td>
-                    <td className="py-3">{formatDate(user.createdAt)}</td>
-                    <td className="py-3 text-center">{user.soloTastings}</td>
-                    <td className="py-3 text-center">{user.groupTastings}</td>
-                    <td className="py-3 text-center font-semibold">{user.tastingsCompleted}</td>
-                    <td className="py-3">{formatDate(user.lastTastingDate)}</td>
-                    <td className="py-3">
-                      <Badge variant={levelColor(user.tastingLevel)}>{user.tastingLevel}</Badge>
-                    </td>
-                    <td className="py-3">{user.onboardingCompleted ? 'Yes' : 'No'}</td>
-                  </tr>
-                ))}
+                {filteredUsers.map((user) => {
+                  const isExpanded = expandedEmail === user.email;
+                  return (
+                    <tr key={user.email} className="border-b last:border-0 group">
+                      <td colSpan={9} className="p-0">
+                        <div
+                          className="flex items-center cursor-pointer hover:bg-muted/50 transition-colors"
+                          onClick={() => setExpandedEmail(isExpanded ? null : user.email)}
+                        >
+                          <div className="py-3 pl-2 w-6">
+                            {isExpanded
+                              ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                              : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+                            }
+                          </div>
+                          <div className="py-3 flex-1 font-mono text-xs">{user.email}</div>
+                          <div className="py-3 w-32">{formatDate(user.createdAt)}</div>
+                          <div className="py-3 w-16 text-center">{user.soloTastings}</div>
+                          <div className="py-3 w-16 text-center">{user.groupTastings}</div>
+                          <div className="py-3 w-16 text-center font-semibold">{user.tastingsCompleted}</div>
+                          <div className="py-3 w-32">{formatDate(user.lastTastingDate)}</div>
+                          <div className="py-3 w-24">
+                            <Badge variant={levelColor(user.tastingLevel)}>{user.tastingLevel}</Badge>
+                          </div>
+                          <div className="py-3 w-20 pr-2">{user.onboardingCompleted ? 'Yes' : 'No'}</div>
+                        </div>
+                        {isExpanded && (
+                          <div className="border-t bg-muted/30">
+                            <UserDetailPanel email={user.email} />
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/client/src/pages/AdminDashboard.tsx
+++ b/client/src/pages/AdminDashboard.tsx
@@ -1,9 +1,13 @@
-import { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
-import { Users, Wine, Map, CalendarDays, Activity, CheckCircle, User, UsersRound, ChevronDown, ChevronRight, Search } from 'lucide-react';
+import { Users, Wine, Map, CalendarDays, Activity, CheckCircle, User, UsersRound, ChevronDown, ChevronRight, Search, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
+
+type SortKey = 'email' | 'createdAt' | 'soloTastings' | 'groupTastings'
+  | 'tastingsCompleted' | 'lastTastingDate' | 'tastingLevel' | 'onboardingCompleted';
+type SortDir = 'asc' | 'desc';
 
 interface EngagementData {
   summary: {
@@ -162,9 +166,24 @@ function UserDetailPanel({ email }: { email: string }) {
   );
 }
 
+function SortIcon({ sortKey: currentSort, sortDir, columnKey }: {
+  sortKey: SortKey;
+  sortDir: SortDir;
+  columnKey: SortKey;
+}) {
+  if (currentSort !== columnKey) return <ArrowUpDown className="h-3 w-3 ml-1 inline opacity-40" />;
+  return sortDir === 'asc'
+    ? <ArrowUp className="h-3 w-3 ml-1 inline" />
+    : <ArrowDown className="h-3 w-3 ml-1 inline" />;
+}
+
 export default function AdminDashboard() {
   const [search, setSearch] = useState('');
   const [expandedEmail, setExpandedEmail] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>('createdAt');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [levelFilter, setLevelFilter] = useState('');
+  const [onboardedFilter, setOnboardedFilter] = useState('');
 
   const { data, isLoading, error } = useQuery<EngagementData>({
     queryKey: ['/api/admin/engagement'],
@@ -175,6 +194,68 @@ export default function AdminDashboard() {
     },
     refetchInterval: 60000,
   });
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(key);
+      setSortDir('desc');
+    }
+  };
+
+  const sortedUsers = useMemo(() => {
+    if (!data) return [];
+
+    let users = data.recentUsers;
+
+    // Apply filters
+    if (search) {
+      users = users.filter(u => u.email.toLowerCase().includes(search.toLowerCase()));
+    }
+    if (levelFilter) {
+      users = users.filter(u => u.tastingLevel === levelFilter);
+    }
+    if (onboardedFilter) {
+      users = users.filter(u =>
+        onboardedFilter === 'yes' ? u.onboardingCompleted : !u.onboardingCompleted
+      );
+    }
+
+    // Sort
+    return [...users].sort((a, b) => {
+      const dir = sortDir === 'asc' ? 1 : -1;
+
+      switch (sortKey) {
+        case 'email':
+          return dir * a.email.localeCompare(b.email);
+        case 'createdAt':
+          return dir * (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+        case 'soloTastings':
+          return dir * (a.soloTastings - b.soloTastings);
+        case 'groupTastings':
+          return dir * (a.groupTastings - b.groupTastings);
+        case 'tastingsCompleted':
+          return dir * (a.tastingsCompleted - b.tastingsCompleted);
+        case 'lastTastingDate': {
+          const aTime = a.lastTastingDate ? new Date(a.lastTastingDate).getTime() : 0;
+          const bTime = b.lastTastingDate ? new Date(b.lastTastingDate).getTime() : 0;
+          if (!a.lastTastingDate && !b.lastTastingDate) return 0;
+          if (!a.lastTastingDate) return 1;
+          if (!b.lastTastingDate) return -1;
+          return dir * (aTime - bTime);
+        }
+        case 'tastingLevel': {
+          const order: Record<string, number> = { intro: 0, intermediate: 1, advanced: 2 };
+          return dir * ((order[a.tastingLevel] ?? -1) - (order[b.tastingLevel] ?? -1));
+        }
+        case 'onboardingCompleted':
+          return dir * (Number(a.onboardingCompleted) - Number(b.onboardingCompleted));
+        default:
+          return 0;
+      }
+    });
+  }, [data, search, levelFilter, onboardedFilter, sortKey, sortDir]);
 
   if (isLoading) {
     return (
@@ -192,11 +273,9 @@ export default function AdminDashboard() {
     );
   }
 
-  const { summary, recentUsers, journeys, sessions } = data;
+  const { summary, journeys, sessions } = data;
 
-  const filteredUsers = search
-    ? recentUsers.filter(u => u.email.toLowerCase().includes(search.toLowerCase()))
-    : recentUsers;
+  const thClass = "pb-3 font-medium text-muted-foreground cursor-pointer select-none hover:text-foreground transition-colors";
 
   return (
     <div className="min-h-screen bg-background p-6 max-w-7xl mx-auto">
@@ -256,16 +335,37 @@ export default function AdminDashboard() {
 
       {/* Users Table */}
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Users ({filteredUsers.length})</CardTitle>
-          <div className="relative w-64">
-            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-            <Input
-              placeholder="Filter by email..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-8"
-            />
+        <CardHeader className="flex flex-row items-center justify-between gap-4 flex-wrap">
+          <CardTitle>Users ({sortedUsers.length})</CardTitle>
+          <div className="flex items-center gap-3">
+            <select
+              value={levelFilter}
+              onChange={(e) => setLevelFilter(e.target.value)}
+              className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="">All levels</option>
+              <option value="intro">Intro</option>
+              <option value="intermediate">Intermediate</option>
+              <option value="advanced">Advanced</option>
+            </select>
+            <select
+              value={onboardedFilter}
+              onChange={(e) => setOnboardedFilter(e.target.value)}
+              className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="">All users</option>
+              <option value="yes">Onboarded</option>
+              <option value="no">Not onboarded</option>
+            </select>
+            <div className="relative w-64">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Filter by email..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-8"
+              />
+            </div>
           </div>
         </CardHeader>
         <CardContent>
@@ -273,55 +373,69 @@ export default function AdminDashboard() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b text-left">
-                  <th className="pb-3 w-6"></th>
-                  <th className="pb-3 font-medium text-muted-foreground">Email</th>
-                  <th className="pb-3 font-medium text-muted-foreground">Signed Up</th>
-                  <th className="pb-3 font-medium text-muted-foreground text-center">
+                  <th className="pb-3 w-8"></th>
+                  <th className={thClass} onClick={() => handleSort('email')}>
+                    Email <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="email" />
+                  </th>
+                  <th className={thClass} onClick={() => handleSort('createdAt')}>
+                    Signed Up <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="createdAt" />
+                  </th>
+                  <th className={`${thClass} text-center`} onClick={() => handleSort('soloTastings')}>
                     <User className="h-3.5 w-3.5 inline" /> Solo
+                    <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="soloTastings" />
                   </th>
-                  <th className="pb-3 font-medium text-muted-foreground text-center">
+                  <th className={`${thClass} text-center`} onClick={() => handleSort('groupTastings')}>
                     <UsersRound className="h-3.5 w-3.5 inline" /> Group
+                    <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="groupTastings" />
                   </th>
-                  <th className="pb-3 font-medium text-muted-foreground text-center">Total</th>
-                  <th className="pb-3 font-medium text-muted-foreground">Last Active</th>
-                  <th className="pb-3 font-medium text-muted-foreground">Level</th>
-                  <th className="pb-3 font-medium text-muted-foreground">Onboarded</th>
+                  <th className={`${thClass} text-center`} onClick={() => handleSort('tastingsCompleted')}>
+                    Total <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="tastingsCompleted" />
+                  </th>
+                  <th className={thClass} onClick={() => handleSort('lastTastingDate')}>
+                    Last Active <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="lastTastingDate" />
+                  </th>
+                  <th className={thClass} onClick={() => handleSort('tastingLevel')}>
+                    Level <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="tastingLevel" />
+                  </th>
+                  <th className={thClass} onClick={() => handleSort('onboardingCompleted')}>
+                    Onboarded <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="onboardingCompleted" />
+                  </th>
                 </tr>
               </thead>
               <tbody>
-                {filteredUsers.map((user) => {
+                {sortedUsers.map((user) => {
                   const isExpanded = expandedEmail === user.email;
                   return (
-                    <tr key={user.email} className="border-b last:border-0 group">
-                      <td colSpan={9} className="p-0">
-                        <div
-                          className="flex items-center cursor-pointer hover:bg-muted/50 transition-colors"
-                          onClick={() => setExpandedEmail(isExpanded ? null : user.email)}
-                        >
-                          <div className="py-3 pl-2 w-6">
-                            {isExpanded
-                              ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                              : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-                            }
-                          </div>
-                          <div className="py-3 flex-1 font-mono text-xs">{user.email}</div>
-                          <div className="py-3 w-32">{formatDate(user.createdAt)}</div>
-                          <div className="py-3 w-16 text-center">{user.soloTastings}</div>
-                          <div className="py-3 w-16 text-center">{user.groupTastings}</div>
-                          <div className="py-3 w-16 text-center font-semibold">{user.tastingsCompleted}</div>
-                          <div className="py-3 w-32">{formatDate(user.lastTastingDate)}</div>
-                          <div className="py-3 w-24">
-                            <Badge variant={levelColor(user.tastingLevel)}>{user.tastingLevel}</Badge>
-                          </div>
-                          <div className="py-3 w-20 pr-2">{user.onboardingCompleted ? 'Yes' : 'No'}</div>
-                        </div>
-                        {isExpanded && (
-                          <div className="border-t bg-muted/30">
+                    <React.Fragment key={user.email}>
+                      <tr
+                        className="border-b last:border-0 cursor-pointer hover:bg-muted/50 transition-colors"
+                        onClick={() => setExpandedEmail(isExpanded ? null : user.email)}
+                      >
+                        <td className="py-3 pl-2 w-8">
+                          {isExpanded
+                            ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                            : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+                          }
+                        </td>
+                        <td className="py-3 font-mono text-xs">{user.email}</td>
+                        <td className="py-3">{formatDate(user.createdAt)}</td>
+                        <td className="py-3 text-center">{user.soloTastings}</td>
+                        <td className="py-3 text-center">{user.groupTastings}</td>
+                        <td className="py-3 text-center font-semibold">{user.tastingsCompleted}</td>
+                        <td className="py-3">{formatDate(user.lastTastingDate)}</td>
+                        <td className="py-3">
+                          <Badge variant={levelColor(user.tastingLevel)}>{user.tastingLevel}</Badge>
+                        </td>
+                        <td className="py-3">{user.onboardingCompleted ? 'Yes' : 'No'}</td>
+                      </tr>
+                      {isExpanded && (
+                        <tr>
+                          <td colSpan={9} className="bg-muted/30 p-0 border-b">
                             <UserDetailPanel email={user.email} />
-                          </div>
-                        )}
-                      </td>
-                    </tr>
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
                   );
                 })}
               </tbody>

--- a/client/src/pages/AdminDashboard.tsx
+++ b/client/src/pages/AdminDashboard.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Users, Wine, Map, CalendarDays, Activity, CheckCircle, User, UsersRound, ChevronDown, ChevronRight, Search, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
 
 type SortKey = 'email' | 'createdAt' | 'soloTastings' | 'groupTastings'
-  | 'tastingsCompleted' | 'lastTastingDate' | 'tastingLevel' | 'onboardingCompleted';
+  | 'tastingsCompleted' | 'lastTastingDate' | 'lastSeenAt' | 'tastingLevel' | 'onboardingCompleted';
 type SortDir = 'asc' | 'desc';
 
 interface EngagementData {
@@ -28,6 +28,7 @@ interface EngagementData {
     groupTastings: number;
     tastingsCompleted: number;
     lastTastingDate: string | null;
+    lastSeenAt: string | null;
     tastingLevel: string;
     onboardingCompleted: boolean;
   }>;
@@ -238,12 +239,16 @@ export default function AdminDashboard() {
         case 'tastingsCompleted':
           return dir * (a.tastingsCompleted - b.tastingsCompleted);
         case 'lastTastingDate': {
-          const aTime = a.lastTastingDate ? new Date(a.lastTastingDate).getTime() : 0;
-          const bTime = b.lastTastingDate ? new Date(b.lastTastingDate).getTime() : 0;
           if (!a.lastTastingDate && !b.lastTastingDate) return 0;
           if (!a.lastTastingDate) return 1;
           if (!b.lastTastingDate) return -1;
-          return dir * (aTime - bTime);
+          return dir * (new Date(a.lastTastingDate).getTime() - new Date(b.lastTastingDate).getTime());
+        }
+        case 'lastSeenAt': {
+          if (!a.lastSeenAt && !b.lastSeenAt) return 0;
+          if (!a.lastSeenAt) return 1;
+          if (!b.lastSeenAt) return -1;
+          return dir * (new Date(a.lastSeenAt).getTime() - new Date(b.lastSeenAt).getTime());
         }
         case 'tastingLevel': {
           const order: Record<string, number> = { intro: 0, intermediate: 1, advanced: 2 };
@@ -392,7 +397,10 @@ export default function AdminDashboard() {
                     Total <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="tastingsCompleted" />
                   </th>
                   <th className={thClass} onClick={() => handleSort('lastTastingDate')}>
-                    Last Active <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="lastTastingDate" />
+                    Last Tasting <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="lastTastingDate" />
+                  </th>
+                  <th className={thClass} onClick={() => handleSort('lastSeenAt')}>
+                    Last Seen <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="lastSeenAt" />
                   </th>
                   <th className={thClass} onClick={() => handleSort('tastingLevel')}>
                     Level <SortIcon sortKey={sortKey} sortDir={sortDir} columnKey="tastingLevel" />
@@ -423,6 +431,7 @@ export default function AdminDashboard() {
                         <td className="py-3 text-center">{user.groupTastings}</td>
                         <td className="py-3 text-center font-semibold">{user.tastingsCompleted}</td>
                         <td className="py-3">{formatDate(user.lastTastingDate)}</td>
+                        <td className="py-3">{formatDate(user.lastSeenAt)}</td>
                         <td className="py-3">
                           <Badge variant={levelColor(user.tastingLevel)}>{user.tastingLevel}</Badge>
                         </td>
@@ -430,7 +439,7 @@ export default function AdminDashboard() {
                       </tr>
                       {isExpanded && (
                         <tr>
-                          <td colSpan={9} className="bg-muted/30 p-0 border-b">
+                          <td colSpan={10} className="bg-muted/30 p-0 border-b">
                             <UserDetailPanel email={user.email} />
                           </td>
                         </tr>

--- a/client/src/pages/HomeTastings.tsx
+++ b/client/src/pages/HomeTastings.tsx
@@ -97,7 +97,7 @@ export default function HomeTastings() {
     },
   });
 
-  // Get preferences
+  // Get solo preferences (for summary display and fallback stats)
   const { data: preferencesData } = useQuery<PreferencesData>({
     queryKey: ["/api/solo/preferences"],
     queryFn: async () => {
@@ -321,7 +321,7 @@ export default function HomeTastings() {
               ))}
             </div>
           ) : (
-            <EmptyTastingsCard onStartTasting={() => setLocation("/tasting/new")} />
+            <EmptyTastingsCard onStartTasting={() => setLocation("/tasting/new")} groupCount={stats.group} />
           )}
         </motion.div>
       </div>
@@ -359,17 +359,21 @@ function StatCard({
 }
 
 // Empty State Card
-function EmptyTastingsCard({ onStartTasting }: { onStartTasting: () => void }) {
+function EmptyTastingsCard({ onStartTasting, groupCount = 0 }: { onStartTasting: () => void; groupCount?: number }) {
   return (
     <div className="text-center py-12 bg-gradient-to-br from-white/5 to-white/0 rounded-2xl border border-white/10">
       <Wine className="w-12 h-12 text-white/30 mx-auto mb-4" />
-      <p className="text-white/60 mb-4">No tastings yet</p>
+      <p className="text-white/60 mb-4">
+        {groupCount > 0
+          ? `You've tasted ${groupCount} wine${groupCount !== 1 ? 's' : ''} in group sessions. Try a solo tasting to deepen your profile.`
+          : "No tastings yet"}
+      </p>
       <Button
         onClick={onStartTasting}
         variant="outline"
         className="border-white/10 text-white hover:bg-white/10"
       >
-        Start Your First Tasting
+        {groupCount > 0 ? "Start Solo Tasting" : "Start Your First Tasting"}
       </Button>
     </div>
   );

--- a/client/src/pages/HomeV2.tsx
+++ b/client/src/pages/HomeV2.tsx
@@ -412,7 +412,7 @@ function SoloTabContent({ user, onLogout }: TabContentProps) {
     },
   });
 
-  // Get preferences
+  // Get solo preferences (fallback for stats when dashboard hasn't loaded)
   const { data: preferencesData } = useQuery<PreferencesData>({
     queryKey: ["/api/solo/preferences"],
     queryFn: async () => {
@@ -567,7 +567,7 @@ function SoloTabContent({ user, onLogout }: TabContentProps) {
           transition={{ delay: 0.3 }}
         >
           <h2 className="text-lg font-semibold text-white mb-4">
-            Recent Solo Tastings
+            Recent Tastings
           </h2>
 
           {tastingsLoading ? (
@@ -646,16 +646,20 @@ function SoloTabContent({ user, onLogout }: TabContentProps) {
               >
                 <Wine className="w-14 h-14 text-purple-400/40 mx-auto mb-4" />
               </motion.div>
-              <p className="text-white/70 text-lg font-medium mb-2">Your journal awaits</p>
+              <p className="text-white/70 text-lg font-medium mb-2">
+                {stats.group > 0 ? "Your solo journal awaits" : "Your journal awaits"}
+              </p>
               <p className="text-white/40 text-sm mb-6 max-w-[240px] mx-auto">
-                Taste your first wine and start building your personal palate profile
+                {stats.group > 0
+                  ? `You've tasted ${stats.group} wine${stats.group !== 1 ? 's' : ''} in group sessions. Try a solo tasting to deepen your personal profile.`
+                  : "Taste your first wine and start building your personal palate profile"}
               </p>
               <Button
                 onClick={() => setLocation("/tasting/new")}
                 className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white px-6"
               >
                 <Plus className="w-4 h-4 mr-2" />
-                First Tasting
+                {stats.group > 0 ? "Start Solo Tasting" : "First Tasting"}
               </Button>
             </motion.div>
           )}
@@ -1164,7 +1168,7 @@ function DashboardTabContent({ user, onLogout }: TabContentProps) {
       enabled: !!user.email,
     });
 
-  // Fetch solo preferences
+  // Fetch solo preferences (fallback stats)
   const { data: soloPreferences } = useQuery<PreferencesData>({
     queryKey: ["/api/solo/preferences"],
   });

--- a/docs/plans/2026-03-20-feat-group-data-into-taste-profile-plan.md
+++ b/docs/plans/2026-03-20-feat-group-data-into-taste-profile-plan.md
@@ -1,0 +1,640 @@
+---
+title: "feat: Integrate group tasting data into taste profile and home page"
+type: feat
+date: 2026-03-20
+deepened: 2026-03-20
+---
+
+# Integrate Group Tasting Data Into Taste Profile & Home Page
+
+## Enhancement Summary
+
+**Deepened on:** 2026-03-20
+**Sections enhanced:** All phases + new prerequisites
+**Research agents used:** TypeScript Reviewer, Performance Oracle, Security Sentinel, Architecture Strategist, Data Integrity Guardian, Code Simplicity Reviewer, Pattern Recognition Specialist, Drizzle ORM Research, TanStack Query Research, Silent Data Loss Learning Analysis, Data Aggregation Best Practices
+
+### Key Improvements From Research
+1. **Reordered phases** — fix broken `getGroupTastingPreferences` FIRST (Phase 0) since it's a prerequisite for everything else
+2. **Separation of concerns** — storage returns raw rows, normalization lives in service layer only
+3. **Simplified category mapping** — lowercase + 4-entry map instead of 8-entry case-variant map
+4. **Database indexes** — add `idx_participants_email` and `idx_slides_type` before querying at scale
+5. **Hardened normalization** — division-by-zero guard, input clamping, boundary validation
+6. **Parallel queries** — `Promise.all` for independent DB calls in fingerprint
+7. **Unmapped category logging** — log warnings instead of silently skipping unknown categories
+8. **Use Drizzle builder** — avoid raw SQL, use Drizzle's `.innerJoin()` pattern for type safety
+9. **Equal weighting** — start with 1.0 weight for group signals (same as solo full), simplify later if needed
+10. **Leaner return types** — drop `groupWines` and `groupTastingCount` from storage; derive in service layer
+
+### New Considerations Discovered
+- Email case sensitivity bug exists in `getAllParticipantsByEmail` — fix alongside this work
+- `/api/dashboard/:email/*` routes lack auth guards (pre-existing, out of scope but flagged)
+- Same wine tasted across multiple group sessions needs dedup strategy
+- Bayesian averaging for sparse data could improve confidence scoring (future enhancement)
+
+---
+
+## Overview
+
+Group tasting data is partially integrated (dashboard wine collection, preference bars on `/api/dashboard/:email/preferences`) but completely absent from the taste profile synthesis pipeline, the solo home tab, and the `/api/me/summary` endpoint. Users who have only done group tastings see empty states telling them to "complete a tasting" — despite having real tasting history.
+
+This plan integrates group response data into all user-facing surfaces so both data sources contribute equally to a user's wine identity.
+
+## Problem Statement
+
+Three independent data pipelines power user-facing surfaces, and all three query only the `tastings` table (solo):
+
+| Surface | Endpoint | Group Data? |
+|---|---|---|
+| Taste Profile bars (TasteIdentityCard) | `/api/me/taste-profile` → `getOrSynthesizeProfile(userId)` | **No** |
+| Profile fingerprint (cache key) | `getProfileFingerprint(userId)` | **No** |
+| Solo tab preferences | `/api/solo/preferences` → `getUserPreferences(userId)` | **No** |
+| Solo tab recent activity | `/api/solo/tastings` | **No** |
+| `/api/me/summary` stats | queries `tastings` table | **No** |
+| Dashboard preference bars | `/api/dashboard/:email/preferences` | **Yes** (but broken — returns nulls) |
+
+A group-only user like `violamgx@gmail.com` sees:
+- TasteIdentityCard: "Your Profile is Forming"
+- Solo tab: "Your journal awaits" with CTA "Start your first tasting"
+- Stats: "0 tastings completed"
+
+## Critical Discovery: Data Shape Mismatch
+
+### Solo tastings (`tastings` table)
+- One row per wine, rich nested blob in `responses` JSONB
+- Traits at: `responses.taste.sweetness` or `responses.structure.sweetness` (1-5 scale)
+- Also contains: flavors array, aromas array, notes, overall rating, wouldBuyAgain
+
+### Group responses (`responses` table)
+- One row per participant per slide
+- Score stored as: `answer_json.selectedScore` (numeric)
+- Trait identity NOT in answer — lives in `slides.payloadJson.category` (e.g., `"Body"`, `"Tannins"`)
+- **Mixed scales**: Body slides use 1-5, most others use 1-10
+- Wine metadata lives in `packageWines` table, joined via `slides.packageWineId`
+
+### Existing `getGroupTastingPreferences` IS broken
+It queries `answer_json->>'sweetness'` directly (storage.ts:4884), but actual group answers are `{ selectedScore: 7 }` with the trait name in the slide's `payloadJson.category`, not in the answer. This means the preferences endpoint returns null trait values for group data, falling back to session count only.
+
+## Proposed Solution
+
+### Architecture: Adapter Pattern with Clean Layer Separation
+
+**Research insight**: Storage layer returns raw rows. All normalization (category mapping, scale conversion, weighting) lives in the service layer. This keeps the storage layer a pure data accessor and makes the mapping logic testable in isolation.
+
+```
+Storage Layer (raw data):
+  Solo:  tastings table → getTastingSignalsForProfile(userId) → raw solo rows
+  Group: responses + slides + packageWines → getGroupResponsesForProfile(email) → raw group rows
+
+Service Layer (normalization + synthesis):
+  normalizeGroupResponses(rawRows) → groupTraitSignals[]
+  buildSignalSummary(soloSignals, groupSignals) → mergedSignalSummary
+  synthesizeProfile(summary) → TasteProfile
+```
+
+### Category-to-Trait Mapping (Simplified)
+
+**Research insight**: Normalize to lowercase at the call site, use a minimal 4-entry map instead of 8 case variants. Log unmapped categories as warnings (per silent-data-loss learning).
+
+```typescript
+// server/services/tasteProfileService.ts
+const GROUP_CATEGORY_TO_TRAIT: ReadonlyMap<string, TraitName> = new Map([
+  ['body', 'body'],
+  ['tannins', 'tannins'],
+  ['acidity', 'acidity'],
+  ['sweetness', 'sweetness'],
+]);
+
+// Categories that are intentionally excluded (not trait bars):
+// 'intensity' (aroma), 'finish' (length), 'overall' (rating), 'fruit', 'secondary', 'tertiary'
+
+function mapCategoryToTrait(category: string): TraitName | null {
+  const trait = GROUP_CATEGORY_TO_TRAIT.get(category.toLowerCase()) ?? null;
+  if (!trait && category) {
+    console.warn(`[tasteProfile] Unmapped group category: "${category}"`);
+  }
+  return trait;
+}
+```
+
+### Scale Normalization (Hardened)
+
+**Research insight**: Guard against division by zero, clamp inputs to valid range, handle edge cases.
+
+```typescript
+function normalizeToFivePointScale(value: number, scaleMax: number): number {
+  if (scaleMax <= 1) return 3; // Degenerate scale — return midpoint
+  const clamped = Math.max(1, Math.min(value, scaleMax));
+  if (scaleMax === 5) return clamped;
+  // Linear map: [1, scaleMax] → [1, 5]
+  return 1 + ((clamped - 1) / (scaleMax - 1)) * 4;
+}
+```
+
+### Signal Weighting
+
+**Research insight**: Start simple — weight group signals at 1.0 (same as full solo tastings). Both provide explicit per-trait ratings. Differentiate weights later only if data quality issues emerge.
+
+```typescript
+// Named constants, centralized
+const SIGNAL_WEIGHT = {
+  FULL_SOLO: 1.0,    // Full tasting with all trait sliders
+  GROUP: 1.0,         // Group per-trait scale responses (same fidelity)
+  QUICK_RATE: 0.5,    // Quick rate — overall only, no per-trait data
+} as const;
+```
+
+---
+
+## Implementation Phases
+
+### Phase 0: Prerequisites (Do First)
+
+**Goal**: Fix the broken foundation and add indexes before building on top.
+
+#### 0a. Add database indexes
+
+**File**: `shared/schema.ts` (add indexes), then `npm run db:push`
+
+The group signal queries will JOIN `participants` by email and filter `slides` by type. Without indexes, these are full table scans.
+
+```typescript
+// Add to schema.ts index definitions
+export const participantsEmailIdx = index('idx_participants_email')
+  .on(participants.email);
+
+export const slidesTypeIdx = index('idx_slides_type')
+  .on(slides.type);
+```
+
+**Research insight (Performance Oracle)**: These indexes are critical. The `participants` table grows with every group session. Without `idx_participants_email`, every fingerprint check and group signal query scans the full table.
+
+#### 0b. Fix `getGroupTastingPreferences` (storage.ts:4865-4910)
+
+**File**: `server/storage.ts`
+
+This is the prerequisite for everything. The current implementation queries `answer_json->>'sweetness'` which doesn't match actual data. Fix to JOIN through slides:
+
+**Storage layer** — return raw rows only:
+
+```typescript
+async getGroupScaleResponses(participantIds: number[]): Promise<Array<{
+  category: string;
+  scaleMax: number;
+  score: number;
+}>> {
+  if (participantIds.length === 0) return [];
+
+  return db.select({
+    category: sql<string>`${slides.payloadJson}->>'category'`,
+    scaleMax: sql<number>`(${slides.payloadJson}->>'scale_max')::int`,
+    score: sql<number>`(${responses.answerJson}->>'selectedScore')::numeric`,
+  })
+  .from(responses)
+  .innerJoin(slides, eq(responses.slideId, slides.id))
+  .where(
+    and(
+      inArray(responses.participantId, participantIds),
+      eq(sql`${slides.payloadJson}->>'question_type'`, 'scale'),
+      isNotNull(sql`${responses.answerJson}->>'selectedScore'`),
+    )
+  );
+}
+```
+
+**Service layer** — map categories, normalize scales, compute averages:
+
+```typescript
+function computeGroupPreferences(
+  rawRows: Array<{ category: string; scaleMax: number; score: number }>
+): Record<TraitName, number | null> {
+  const traitAccum = new Map<TraitName, number[]>();
+
+  for (const row of rawRows) {
+    const trait = mapCategoryToTrait(row.category);
+    if (!trait) continue;
+
+    const normalized = normalizeToFivePointScale(row.score, row.scaleMax);
+    const existing = traitAccum.get(trait) ?? [];
+    existing.push(normalized);
+    traitAccum.set(trait, existing);
+  }
+
+  const result: Record<string, number | null> = {};
+  for (const trait of ['sweetness', 'acidity', 'tannins', 'body'] as TraitName[]) {
+    const values = traitAccum.get(trait);
+    result[trait] = values ? values.reduce((a, b) => a + b, 0) / values.length : null;
+  }
+  return result as Record<TraitName, number | null>;
+}
+```
+
+**Why first**: This fixes the existing broken dashboard preference bars AND validates the category→trait mapping before using it in the synthesis pipeline.
+
+#### 0c. Fix email case sensitivity
+
+**File**: `server/storage.ts` — `getAllParticipantsByEmail`
+
+**Research insight (Data Integrity Guardian)**: The current function does case-sensitive email matching. Normalize email to lowercase at the call site (cheaper than `LOWER()` in SQL which prevents index usage):
+
+```typescript
+async getAllParticipantsByEmail(email: string): Promise<Participant[]> {
+  const normalizedEmail = email.toLowerCase();
+  // ... existing query using normalizedEmail
+}
+```
+
+Apply the same normalization in all new methods that look up participants by email.
+
+---
+
+### Phase 1: Backend — Group Signal Extraction (Core Fix)
+
+**Goal**: Feed group data into the taste profile synthesis pipeline.
+
+#### 1a. New storage method: `getGroupResponsesForProfile(email)`
+
+**File**: `server/storage.ts`
+
+**Research insight (Architecture + Pattern)**: Use Drizzle query builder (not raw SQL) for type safety. Return raw rows — normalization happens in the service layer.
+
+```typescript
+async getGroupResponsesForProfile(email: string): Promise<Array<{
+  responseId: number;
+  selectedScore: number | null;
+  answeredAt: Date | null;
+  category: string | null;
+  scaleMax: number | null;
+  questionType: string | null;
+  packageWineId: number | null;
+}>> {
+  const normalizedEmail = email.toLowerCase();
+
+  const rows = await db.select({
+    responseId: responses.id,
+    selectedScore: sql<number | null>`(${responses.answerJson}->>'selectedScore')::numeric`,
+    answeredAt: responses.answeredAt,
+    category: sql<string | null>`${slides.payloadJson}->>'category'`,
+    scaleMax: sql<number | null>`(${slides.payloadJson}->>'scale_max')::int`,
+    questionType: sql<string | null>`${slides.payloadJson}->>'question_type'`,
+    packageWineId: slides.packageWineId,
+  })
+  .from(responses)
+  .innerJoin(slides, eq(responses.slideId, slides.id))
+  .innerJoin(participants, eq(responses.participantId, participants.id))
+  .where(
+    and(
+      eq(sql`LOWER(${participants.email})`, normalizedEmail),
+      eq(slides.type, 'question'),
+    )
+  )
+  .orderBy(desc(responses.answeredAt))
+  .limit(500);  // Safety limit — 500 responses ≈ 50 sessions × 10 slides
+
+  return rows;
+}
+```
+
+**Research insight (Performance Oracle)**: The `LIMIT 500` prevents unbounded result sets. For most users this returns all data; power users with 50+ sessions would need pagination (future concern).
+
+**Note on LOWER()**: We use `LOWER()` here despite the performance note because `idx_participants_email` is a btree index. For the small result sets we expect, the sequential scan cost is negligible. If this becomes a hot path, we can add a functional index `CREATE INDEX ON participants (LOWER(email))`.
+
+#### 1b. Service layer: `normalizeGroupResponses()`
+
+**File**: `server/services/tasteProfileService.ts`
+
+```typescript
+interface GroupTraitSignal {
+  trait: TraitName;
+  value: number;         // normalized to 1-5
+  packageWineId: number;
+  answeredAt: Date;
+}
+
+function normalizeGroupResponses(
+  rawRows: Array<{ /* shape from 1a */ }>
+): GroupTraitSignal[] {
+  const signals: GroupTraitSignal[] = [];
+
+  for (const row of rawRows) {
+    if (row.questionType !== 'scale') continue;
+    if (row.selectedScore == null || row.packageWineId == null) continue;
+
+    const trait = mapCategoryToTrait(row.category ?? '');
+    if (!trait) continue;
+
+    signals.push({
+      trait,
+      value: normalizeToFivePointScale(row.selectedScore, row.scaleMax ?? 10),
+      packageWineId: row.packageWineId,
+      answeredAt: row.answeredAt ?? new Date(),
+    });
+  }
+
+  return signals;
+}
+```
+
+#### 1c. Extend `buildSignalSummary` with group signals
+
+**File**: `server/services/tasteProfileService.ts`
+
+Add a `groupTraits` bucket to `ProfileSignalSummary` alongside `explicitTraits` and `implicitTraits`:
+
+```typescript
+interface ProfileSignalSummary {
+  explicitTraits: Map<TraitName, WeightedValue[]>;  // existing — full solo
+  implicitTraits: Map<TraitName, WeightedValue[]>;  // existing — quick rate
+  groupTraits: Map<TraitName, WeightedValue[]>;     // NEW — group responses
+  // ... existing fields (topFlavors, topAromas, ratingsByWineType, etc.)
+}
+```
+
+In `buildSignalSummary()`, merge group signals:
+
+```typescript
+for (const signal of groupSignals) {
+  const existing = summary.groupTraits.get(signal.trait) ?? [];
+  existing.push({ value: signal.value, weight: SIGNAL_WEIGHT.GROUP });
+  summary.groupTraits.set(signal.trait, existing);
+}
+```
+
+In `computeWeightedTraitAverage()` (the deterministic fallback), include `groupTraits`:
+
+```typescript
+function computeWeightedTraitAverage(trait: TraitName, summary: ProfileSignalSummary): number | null {
+  const explicit = summary.explicitTraits.get(trait) ?? [];
+  const implicit = summary.implicitTraits.get(trait) ?? [];
+  const group = summary.groupTraits.get(trait) ?? [];
+
+  const all = [...explicit, ...implicit, ...group];
+  if (all.length === 0) return null;
+
+  const weightedSum = all.reduce((sum, wv) => sum + wv.value * wv.weight, 0);
+  const totalWeight = all.reduce((sum, wv) => sum + wv.weight, 0);
+  return weightedSum / totalWeight;
+}
+```
+
+Group data does NOT contribute to `topFlavors`, `topAromas`, or `recentNotes` (group slides don't capture these).
+
+#### 1d. Update `synthesizeProfile()` to fetch group data
+
+**File**: `server/services/tasteProfileService.ts`
+
+```typescript
+async function synthesizeProfile(userId: number, fingerprint: string, previousProfile: TasteProfile | null) {
+  const soloSignals = await storage.getTastingSignalsForProfile(userId);
+
+  // Get user email for group lookup
+  const user = await storage.getUser(userId);
+  let groupSignals: GroupTraitSignal[] = [];
+  if (user?.email) {
+    const rawGroupRows = await storage.getGroupResponsesForProfile(user.email);
+    groupSignals = normalizeGroupResponses(rawGroupRows);
+  }
+
+  const summary = buildSignalSummary(soloSignals, groupSignals);
+
+  // Count unique group wines for totalTastings
+  const groupWineCount = new Set(groupSignals.map(s => s.packageWineId)).size;
+
+  // Update dataSnapshot
+  summary.totalTastings = summary.soloTastingCount + groupWineCount;
+
+  // Update confidence level
+  summary.confidenceLevel = computeConfidenceLevel(
+    summary.fullSoloCount,
+    summary.quickRateCount,
+    groupWineCount,
+  );
+
+  // ... rest of synthesis (GPT call or deterministic fallback)
+}
+```
+
+#### 1e. Update `computeConfidenceLevel` to include group count
+
+```typescript
+function computeConfidenceLevel(fullCount: number, quickCount: number, groupCount: number): string {
+  const effective = fullCount + groupCount + quickCount * 0.5;
+  if (effective >= 10) return 'established';
+  if (effective >= 5) return 'developing';
+  if (effective >= 2) return 'emerging';
+  return 'new';
+}
+```
+
+#### 1f. Update GPT synthesis prompt
+
+When group data is present, add context to the GPT prompt so it knows some signals may be sparse:
+
+```typescript
+// Add to SYNTHESIS_PROMPT when groupTraits are non-empty
+const groupContext = groupSignals.length > 0
+  ? `\n\nNote: Some trait data comes from group tasting sessions, which provide per-trait ratings but not flavor/aroma details. ${groupWineCount} wines were tasted in group settings.`
+  : '';
+```
+
+#### 1g. Extend `getProfileFingerprint` to include group data
+
+**File**: `server/storage.ts` — `getProfileFingerprint(userId)`
+
+**Research insight (Performance)**: Use `Promise.all` for the independent queries:
+
+```typescript
+async getProfileFingerprint(userId: number): Promise<string> {
+  const [soloResult, user] = await Promise.all([
+    db.select({ id: tastings.id, updatedAt: tastings.updatedAt })
+      .from(tastings).where(eq(tastings.userId, userId)).orderBy(tastings.id),
+    db.query.users.findFirst({
+      where: eq(users.id, userId),
+      columns: { email: true },
+    }),
+  ]);
+
+  let groupContent = '';
+  if (user?.email) {
+    const normalizedEmail = user.email.toLowerCase();
+    const groupResult = await db.select({ id: responses.id, answeredAt: responses.answeredAt })
+      .from(responses)
+      .innerJoin(participants, eq(responses.participantId, participants.id))
+      .where(eq(sql`LOWER(${participants.email})`, normalizedEmail))
+      .orderBy(responses.id);
+
+    groupContent = groupResult.map(r => `g${r.id}:${r.answeredAt?.getTime() ?? 0}`).join(',');
+  }
+
+  const soloContent = soloResult.map(t => `${t.id}:${t.updatedAt?.getTime() ?? 0}`).join(',');
+  const combined = `${soloContent}|${groupContent}`;
+
+  if (!soloContent && !groupContent) return 'empty';
+  return crypto.createHash('sha256').update(combined).digest('hex').slice(0, 16);
+}
+```
+
+#### 1h. Add `groupTastings` to `TasteProfile.dataSnapshot`
+
+**File**: `server/services/tasteProfileService.ts`
+
+```typescript
+interface DataSnapshot {
+  totalTastings: number;        // existing — now solo + group
+  soloTastings: number;         // NEW — solo only count
+  groupTastings: number;        // NEW — unique group wines count
+  lastTastingDate: string;
+  confidenceLevel: string;
+}
+```
+
+This lets the frontend know whether group data contributed, without needing separate API calls.
+
+---
+
+### Phase 2: Backend — Home Page Endpoints
+
+**Goal**: `/api/me/summary` and `/api/solo/preferences` reflect combined data.
+
+#### 2a. Update `/api/me/summary` (dashboard.ts:680-748)
+
+Add group tasting stats alongside solo:
+- `totalGroupTastings`: count of unique sessions
+- `totalCombinedTastings`: solo + group
+- `recentActivity`: interleaved list of recent solo tastings + group sessions, sorted by date
+
+The group session data is available from existing `getAllParticipantsByEmail` → unique `sessionId` values.
+
+#### 2b. Switch `/api/solo/preferences` callers to unified endpoint
+
+Rather than changing the `/api/solo/preferences` semantics (it's correctly named "solo"), update `HomeTastings.tsx` and `HomeV2.tsx` to call `/api/dashboard/:email/preferences` (which already merges both sources, and will work correctly after Phase 0b fix).
+
+**Research insight (TanStack Query)**: Use a query key factory pattern for consistent cache invalidation:
+
+```typescript
+// client/src/lib/queryKeys.ts
+export const preferenceKeys = {
+  all: ['preferences'] as const,
+  solo: (userId: number) => [...preferenceKeys.all, 'solo', userId] as const,
+  unified: (email: string) => [...preferenceKeys.all, 'unified', email] as const,
+};
+```
+
+---
+
+### Phase 3: Frontend — Home Page Empty States & Activity
+
+**Goal**: Group-only users never see misleading empty states.
+
+#### 3a. Fix TasteIdentityCard empty state
+
+**File**: `client/src/components/dashboard/TasteIdentityCard.tsx`
+
+No frontend changes needed if Phase 1 is done correctly — `getOrSynthesizeProfile` will return a real profile for group-only users. The "Your Profile is Forming" state will only show when there's genuinely no data.
+
+#### 3b. Fix solo tab empty state copy
+
+**File**: `client/src/pages/HomeV2.tsx` — lines 637-661
+
+When `tastingsData.tastings.length === 0` but `stats.groupTastings > 0`:
+- Change "Your journal awaits" to "Your solo journal awaits"
+- Change "Taste your first wine..." to "You've tasted {stats.groupTastings} wines in group sessions. Try a solo tasting to deepen your personal profile."
+- Keep the "Start New Tasting" CTA
+
+When both solo and group are 0:
+- Keep current empty state
+
+#### 3c. Show group activity on solo tab
+
+**File**: `client/src/pages/HomeV2.tsx`
+
+Change "Recent Solo Tastings" to "Recent Tastings" and include group session summaries in the activity list. Each group entry shows:
+- Session/package name
+- Number of wines tasted
+- Date
+- "Group" badge (vs "Solo" badge on solo entries)
+
+Data source: the existing `/api/dashboard/:email/history` endpoint already returns group tasting history.
+
+#### 3d. Fix HomeTastings.tsx preferences source
+
+**File**: `client/src/pages/HomeTastings.tsx`
+
+Switch from `/api/solo/preferences` to `/api/dashboard/:email/preferences` for the taste profile summary section, and use `stats.totalCombinedTastings` (from unified stats) for the empty state check.
+
+---
+
+## Acceptance Criteria
+
+- [x] Group-only user sees populated taste profile bars (not "Your Profile is Forming")
+- [x] Group-only user sees activity on home tab (not "Your journal awaits")
+- [x] Mixed user's taste profile reflects both solo + group data
+- [x] Profile fingerprint invalidates when new group responses are submitted
+- [x] Scale normalization: group 1-10 scores map correctly to 1-5 trait bars
+- [x] `dataSnapshot.totalTastings` includes group wine count
+- [x] `dataSnapshot.groupTastings` shows group-specific count
+- [x] Dashboard preference bars work correctly (fix broken `getGroupTastingPreferences`)
+- [x] No regressions for solo-only users
+- [x] Unmapped group categories logged as warnings (not silently dropped)
+- [x] Email matching is case-insensitive throughout
+
+## Edge Cases
+
+- **Participant with null email**: Gracefully excluded — `getGroupResponsesForProfile` returns empty array, no crash
+- **Email casing mismatch** (e.g., `Viola@gmail.com` vs `viola@gmail.com`): Normalize to lowercase at call site before query
+- **Group slides without trait categories** (e.g., text questions, multiple choice): Filtered by `questionType !== 'scale'` check in `normalizeGroupResponses`
+- **Unmapped scale categories** (e.g., `intensity`, `finish`): `mapCategoryToTrait` returns null, logs warning, skips
+- **User who deletes their account**: Group participant records remain orphaned (existing behavior, out of scope)
+- **GPT synthesis threshold**: Count group wines toward the 3-tasting minimum for GPT synthesis, note in prompt that flavors/aromas may be sparse
+- **Division by zero in normalization**: `scaleMax <= 1` returns midpoint (3) as safe fallback
+- **Score out of range**: Clamped to `[1, scaleMax]` before normalization
+- **Same wine across multiple group sessions**: Each session's ratings are independent trait signals — no dedup needed (more data points = better average)
+- **Very large response count (50+ sessions)**: `LIMIT 500` on storage query prevents unbounded results
+- **Null `selectedScore` in response**: Filtered out at both SQL level (`IS NOT NULL`) and TypeScript level (`== null` check)
+
+## Files to Modify
+
+| File | Changes |
+|---|---|
+| `shared/schema.ts` | Add `idx_participants_email` and `idx_slides_type` indexes |
+| `server/storage.ts` | New `getGroupResponsesForProfile(email)`, new `getGroupScaleResponses(participantIds)`, fix `getGroupTastingPreferences`, extend `getProfileFingerprint`, fix `getAllParticipantsByEmail` email casing |
+| `server/services/tasteProfileService.ts` | `mapCategoryToTrait()`, `normalizeToFivePointScale()`, `normalizeGroupResponses()`, `groupTraits` bucket in `ProfileSignalSummary`, update `buildSignalSummary`, `computeConfidenceLevel`, `synthesizeProfile`, GPT prompt context, `dataSnapshot` shape |
+| `server/routes/dashboard.ts` | Update `/api/me/summary` to include group stats + combined activity |
+| `client/src/pages/HomeV2.tsx` | Fix empty state copy, show group activity in solo tab, use unified preferences |
+| `client/src/pages/HomeTastings.tsx` | Switch preferences source to unified endpoint |
+
+## Implementation Order
+
+```
+Phase 0a: Add indexes (schema.ts + db:push)          ← foundation
+Phase 0b: Fix getGroupTastingPreferences              ← validates mapping approach
+Phase 0c: Fix email case sensitivity                  ← data integrity
+Phase 1a: getGroupResponsesForProfile (storage)       ← raw data extraction
+Phase 1b: normalizeGroupResponses (service)            ← normalization layer
+Phase 1c: Extend buildSignalSummary                    ← merge into synthesis
+Phase 1d: Update synthesizeProfile                     ← tie it together
+Phase 1e-f: Confidence + GPT prompt                    ← quality tuning
+Phase 1g: Extend fingerprint                           ← cache invalidation
+Phase 1h: dataSnapshot shape                           ← API contract
+Phase 2a: /api/me/summary                              ← home page stats
+Phase 2b: Switch frontend preference calls             ← use unified data
+Phase 3a-d: Frontend empty states + activity           ← user-facing polish
+```
+
+## What's NOT in Scope
+
+- Retroactive email matching for anonymous participants (null email)
+- Sommelier tips integration with group data
+- Separate "group profile" vs "solo profile" views
+- Changing the Group tab UI
+- Auth guards on `/api/dashboard/:email/*` routes (pre-existing gap, separate ticket)
+- Bayesian averaging for sparse data (future enhancement)
+- Confidence tier display on frontend (future enhancement)
+
+## References
+
+- Existing unified merge pattern: `server/routes/dashboard.ts:184-247`
+- Past learning on schema mapping: `docs/solutions/logic-errors/silent-data-loss-solo-tasting-saves-20260215.md` — always build explicit mapping layers, never assume field names align
+- Group question templates: `server/services/questionGenerator.ts:88-213`
+- Default slide templates: `server/storage.ts:420-540` (shows scale ranges per category)
+- Drizzle ORM JOIN patterns: used throughout `server/storage.ts` (e.g., `getAllParticipantsByEmail`)
+- TanStack Query key factories: https://tkdodo.eu/blog/effective-react-query-keys

--- a/migrations/0004_thankful_korg.sql
+++ b/migrations/0004_thankful_korg.sql
@@ -1,0 +1,152 @@
+CREATE TABLE "ai_response_cache" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_email" text NOT NULL,
+	"cache_key" text NOT NULL,
+	"fingerprint" text NOT NULL,
+	"response_data" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "ai_response_cache_user_email_cache_key_unique" UNIQUE("user_email","cache_key")
+);
+--> statement-breakpoint
+CREATE TABLE "chapter_completions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"chapter_id" integer NOT NULL,
+	"tasting_id" integer NOT NULL,
+	"wine_photo_url" text,
+	"wine_validation" jsonb,
+	"completed_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "chapter_completions_user_id_chapter_id_unique" UNIQUE("user_id","chapter_id")
+);
+--> statement-breakpoint
+CREATE TABLE "chapters" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"journey_id" integer NOT NULL,
+	"chapter_number" integer NOT NULL,
+	"title" varchar(200) NOT NULL,
+	"description" text,
+	"wine_requirements" jsonb,
+	"learning_objectives" jsonb,
+	"tasting_prompts" jsonb,
+	"completion_criteria" jsonb,
+	"shopping_tips" text,
+	"price_range" jsonb,
+	"alternatives" jsonb,
+	"ask_for" text,
+	"wine_options" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "chapters_journey_id_chapter_number_unique" UNIQUE("journey_id","chapter_number")
+);
+--> statement-breakpoint
+CREATE TABLE "generated_questions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"chapter_completion_id" integer NOT NULL,
+	"questions" jsonb NOT NULL,
+	"wine_context" jsonb NOT NULL,
+	"generated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "journeys" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"liaison_id" integer,
+	"title" varchar(200) NOT NULL,
+	"description" text,
+	"difficulty_level" varchar(20) DEFAULT 'beginner' NOT NULL,
+	"estimated_duration" varchar(50),
+	"wine_type" varchar(50),
+	"cover_image_url" text,
+	"is_published" boolean DEFAULT false NOT NULL,
+	"total_chapters" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sommelier_chats" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"title" varchar(200),
+	"summary" text,
+	"last_summary_at" timestamp,
+	"message_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sommelier_messages" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"chat_id" integer NOT NULL,
+	"role" varchar(20) NOT NULL,
+	"content" text NOT NULL,
+	"image_description" text,
+	"metadata" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_journeys" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"journey_id" integer NOT NULL,
+	"current_chapter" integer DEFAULT 1 NOT NULL,
+	"completed_chapters" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"started_at" timestamp DEFAULT now() NOT NULL,
+	"last_activity_at" timestamp DEFAULT now() NOT NULL,
+	"completed_at" timestamp,
+	CONSTRAINT "user_journeys_user_id_journey_id_unique" UNIQUE("user_id","journey_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_taste_profiles" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"profile_data" jsonb NOT NULL,
+	"fingerprint" text NOT NULL,
+	"synthesized_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_taste_profiles_user_id_unique" UNIQUE("user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "wine_characteristics_cache" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"wine_signature" varchar(500) NOT NULL,
+	"characteristics" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "wine_characteristics_cache_wine_signature_unique" UNIQUE("wine_signature")
+);
+--> statement-breakpoint
+ALTER TABLE "tastings" ADD COLUMN "wine_characteristics" jsonb;--> statement-breakpoint
+ALTER TABLE "tastings" ADD COLUMN "recommendations" jsonb;--> statement-breakpoint
+ALTER TABLE "tastings" ADD COLUMN "tasting_mode" varchar(20) DEFAULT 'full' NOT NULL;--> statement-breakpoint
+ALTER TABLE "tastings" ADD COLUMN "updated_at" timestamp DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "tasting_level" varchar(20) DEFAULT 'intro' NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "tastings_completed" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "level_up_prompt_eligible" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "wine_archetype" varchar(100);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "onboarding_completed" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "onboarding_data" jsonb;--> statement-breakpoint
+ALTER TABLE "chapter_completions" ADD CONSTRAINT "chapter_completions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "chapter_completions" ADD CONSTRAINT "chapter_completions_chapter_id_chapters_id_fk" FOREIGN KEY ("chapter_id") REFERENCES "public"."chapters"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "chapter_completions" ADD CONSTRAINT "chapter_completions_tasting_id_tastings_id_fk" FOREIGN KEY ("tasting_id") REFERENCES "public"."tastings"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "chapters" ADD CONSTRAINT "chapters_journey_id_journeys_id_fk" FOREIGN KEY ("journey_id") REFERENCES "public"."journeys"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "generated_questions" ADD CONSTRAINT "generated_questions_chapter_completion_id_chapter_completions_id_fk" FOREIGN KEY ("chapter_completion_id") REFERENCES "public"."chapter_completions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "journeys" ADD CONSTRAINT "journeys_liaison_id_users_id_fk" FOREIGN KEY ("liaison_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sommelier_chats" ADD CONSTRAINT "sommelier_chats_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sommelier_messages" ADD CONSTRAINT "sommelier_messages_chat_id_sommelier_chats_id_fk" FOREIGN KEY ("chat_id") REFERENCES "public"."sommelier_chats"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_journeys" ADD CONSTRAINT "user_journeys_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_journeys" ADD CONSTRAINT "user_journeys_journey_id_journeys_id_fk" FOREIGN KEY ("journey_id") REFERENCES "public"."journeys"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_taste_profiles" ADD CONSTRAINT "user_taste_profiles_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_ai_response_cache_email" ON "ai_response_cache" USING btree ("user_email");--> statement-breakpoint
+CREATE INDEX "idx_chapter_completions_user" ON "chapter_completions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_chapter_completions_chapter" ON "chapter_completions" USING btree ("chapter_id");--> statement-breakpoint
+CREATE INDEX "idx_chapters_journey" ON "chapters" USING btree ("journey_id");--> statement-breakpoint
+CREATE INDEX "idx_generated_questions_completion" ON "generated_questions" USING btree ("chapter_completion_id");--> statement-breakpoint
+CREATE INDEX "idx_journeys_liaison" ON "journeys" USING btree ("liaison_id");--> statement-breakpoint
+CREATE INDEX "idx_journeys_published" ON "journeys" USING btree ("is_published");--> statement-breakpoint
+CREATE INDEX "idx_journeys_difficulty" ON "journeys" USING btree ("difficulty_level");--> statement-breakpoint
+CREATE INDEX "idx_sommelier_chats_user" ON "sommelier_chats" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_sommelier_chats_updated" ON "sommelier_chats" USING btree ("updated_at");--> statement-breakpoint
+CREATE INDEX "idx_sommelier_messages_chat" ON "sommelier_messages" USING btree ("chat_id");--> statement-breakpoint
+CREATE INDEX "idx_sommelier_messages_chat_created" ON "sommelier_messages" USING btree ("chat_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_user_journeys_user" ON "user_journeys" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_user_journeys_journey" ON "user_journeys" USING btree ("journey_id");--> statement-breakpoint
+CREATE INDEX "idx_wine_cache_signature" ON "wine_characteristics_cache" USING btree ("wine_signature");--> statement-breakpoint
+CREATE INDEX "idx_participants_email" ON "participants" USING btree ("email");--> statement-breakpoint
+CREATE INDEX "idx_slides_type" ON "slides" USING btree ("type");

--- a/migrations/meta/0004_snapshot.json
+++ b/migrations/meta/0004_snapshot.json
@@ -1,0 +1,3051 @@
+{
+  "id": "85079883-139e-4824-8f8d-6a7b0c4e7404",
+  "prevId": "d12deb89-323e-4a51-b980-b90950aeb04a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_response_cache": {
+      "name": "ai_response_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_data": {
+          "name": "response_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_response_cache_email": {
+          "name": "idx_ai_response_cache_email",
+          "columns": [
+            {
+              "expression": "user_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_response_cache_user_email_cache_key_unique": {
+          "name": "ai_response_cache_user_email_cache_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_email",
+            "cache_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_attempts": {
+      "name": "auth_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_auth_attempts_email": {
+          "name": "idx_auth_attempts_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_attempts_ip": {
+          "name": "idx_auth_attempts_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_attempts_attempted_at": {
+          "name": "idx_auth_attempts_attempted_at",
+          "columns": [
+            {
+              "expression": "attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_completions": {
+      "name": "chapter_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wine_photo_url": {
+          "name": "wine_photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wine_validation": {
+          "name": "wine_validation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chapter_completions_user": {
+          "name": "idx_chapter_completions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapter_completions_chapter": {
+          "name": "idx_chapter_completions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_completions_user_id_users_id_fk": {
+          "name": "chapter_completions_user_id_users_id_fk",
+          "tableFrom": "chapter_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chapter_completions_chapter_id_chapters_id_fk": {
+          "name": "chapter_completions_chapter_id_chapters_id_fk",
+          "tableFrom": "chapter_completions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chapter_completions_tasting_id_tastings_id_fk": {
+          "name": "chapter_completions_tasting_id_tastings_id_fk",
+          "tableFrom": "chapter_completions",
+          "tableTo": "tastings",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chapter_completions_user_id_chapter_id_unique": {
+          "name": "chapter_completions_user_id_chapter_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "chapter_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapters": {
+      "name": "chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "journey_id": {
+          "name": "journey_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wine_requirements": {
+          "name": "wine_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learning_objectives": {
+          "name": "learning_objectives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasting_prompts": {
+          "name": "tasting_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_criteria": {
+          "name": "completion_criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shopping_tips": {
+          "name": "shopping_tips",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_range": {
+          "name": "price_range",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ask_for": {
+          "name": "ask_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wine_options": {
+          "name": "wine_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chapters_journey": {
+          "name": "idx_chapters_journey",
+          "columns": [
+            {
+              "expression": "journey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapters_journey_id_journeys_id_fk": {
+          "name": "chapters_journey_id_journeys_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "journeys",
+          "columnsFrom": [
+            "journey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chapters_journey_id_chapter_number_unique": {
+          "name": "chapters_journey_id_chapter_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "journey_id",
+            "chapter_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generated_questions": {
+      "name": "generated_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chapter_completion_id": {
+          "name": "chapter_completion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wine_context": {
+          "name": "wine_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_generated_questions_completion": {
+          "name": "idx_generated_questions_completion",
+          "columns": [
+            {
+              "expression": "chapter_completion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generated_questions_chapter_completion_id_chapter_completions_id_fk": {
+          "name": "generated_questions_chapter_completion_id_chapter_completions_id_fk",
+          "tableFrom": "generated_questions",
+          "tableTo": "chapter_completions",
+          "columnsFrom": [
+            "chapter_completion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_terms": {
+      "name": "glossary_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variations": {
+          "name": "variations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_glossary_terms_term": {
+          "name": "idx_glossary_terms_term",
+          "columns": [
+            {
+              "expression": "term",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_category": {
+          "name": "idx_glossary_terms_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_terms_term_unique": {
+          "name": "glossary_terms_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journeys": {
+      "name": "journeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "liaison_id": {
+          "name": "liaison_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_level": {
+          "name": "difficulty_level",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'beginner'"
+        },
+        "estimated_duration": {
+          "name": "estimated_duration",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wine_type": {
+          "name": "wine_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_chapters": {
+          "name": "total_chapters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_journeys_liaison": {
+          "name": "idx_journeys_liaison",
+          "columns": [
+            {
+              "expression": "liaison_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_journeys_published": {
+          "name": "idx_journeys_published",
+          "columns": [
+            {
+              "expression": "is_published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_journeys_difficulty": {
+          "name": "idx_journeys_difficulty",
+          "columns": [
+            {
+              "expression": "difficulty_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "journeys_liaison_id_users_id_fk": {
+          "name": "journeys_liaison_id_users_id_fk",
+          "tableFrom": "journeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "liaison_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sommelier_id": {
+          "name": "sommelier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_public_id": {
+          "name": "idx_media_public_id",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_entity": {
+          "name": "idx_media_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_sommelier": {
+          "name": "idx_media_sommelier",
+          "columns": [
+            {
+              "expression": "sommelier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media_public_id_unique": {
+          "name": "media_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_wines": {
+      "name": "package_wines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wine_name": {
+          "name": "wine_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wine_description": {
+          "name": "wine_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wine_image_url": {
+          "name": "wine_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wine_type": {
+          "name": "wine_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vintage": {
+          "name": "vintage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grape_varietals": {
+          "name": "grape_varietals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alcohol_content": {
+          "name": "alcohol_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_characteristics": {
+          "name": "expected_characteristics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discussion_questions": {
+          "name": "discussion_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_package_wines_type": {
+          "name": "idx_package_wines_type",
+          "columns": [
+            {
+              "expression": "wine_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_wines_vintage": {
+          "name": "idx_package_wines_vintage",
+          "columns": [
+            {
+              "expression": "vintage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_wines_package_id_packages_id_fk": {
+          "name": "package_wines_package_id_packages_id_fk",
+          "tableFrom": "package_wines",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "package_wines_package_id_position_unique": {
+          "name": "package_wines_package_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "package_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sommelier_id": {
+          "name": "sommelier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_packages_code": {
+          "name": "idx_packages_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "packages_code_unique": {
+          "name": "packages_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_host": {
+          "name": "is_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "progress_ptr": {
+          "name": "progress_ptr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_active": {
+          "name": "last_active",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sommelier_feedback": {
+          "name": "sommelier_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_participants_session": {
+          "name": "idx_participants_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_participants_email_session": {
+          "name": "idx_participants_email_session",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_participants_email": {
+          "name": "idx_participants_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "participants_session_id_sessions_id_fk": {
+          "name": "participants_session_id_sessions_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.responses": {
+      "name": "responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slide_id": {
+          "name": "slide_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_json": {
+          "name": "answer_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_responses_participant": {
+          "name": "idx_responses_participant",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_synced": {
+          "name": "idx_responses_synced",
+          "columns": [
+            {
+              "expression": "synced",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "responses_participant_id_participants_id_fk": {
+          "name": "responses_participant_id_participants_id_fk",
+          "tableFrom": "responses",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "responses_slide_id_slides_id_fk": {
+          "name": "responses_slide_id_slides_id_fk",
+          "tableFrom": "responses",
+          "tableTo": "slides",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "responses_participant_id_slide_id_unique": {
+          "name": "responses_participant_id_slide_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant_id",
+            "slide_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_wine_selections": {
+      "name": "session_wine_selections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_wine_id": {
+          "name": "package_wine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_included": {
+          "name": "is_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_session_wines_session_id": {
+          "name": "idx_session_wines_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_wines_session_position": {
+          "name": "idx_session_wines_session_position",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_session_wine": {
+          "name": "idx_unique_session_wine",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "package_wine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_wine_selections_session_id_sessions_id_fk": {
+          "name": "session_wine_selections_session_id_sessions_id_fk",
+          "tableFrom": "session_wine_selections",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_wine_selections_package_wine_id_package_wines_id_fk": {
+          "name": "session_wine_selections_package_wine_id_package_wines_id_fk",
+          "tableFrom": "session_wine_selections",
+          "tableTo": "package_wines",
+          "columnsFrom": [
+            "package_wine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_participants": {
+          "name": "active_participants",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_package_id": {
+          "name": "idx_sessions_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_short_code": {
+          "name": "idx_sessions_short_code",
+          "columns": [
+            {
+              "expression": "short_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_package_id_packages_id_fk": {
+          "name": "sessions_package_id_packages_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_short_code_unique": {
+          "name": "sessions_short_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "short_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slide_templates": {
+      "name": "slide_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sommelier_id": {
+          "name": "sommelier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_template": {
+          "name": "payload_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slide_templates_type": {
+          "name": "idx_slide_templates_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slides": {
+      "name": "slides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "package_wine_id": {
+          "name": "package_wine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_position": {
+          "name": "global_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generic_questions": {
+          "name": "generic_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "comparable": {
+          "name": "comparable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_slides_package_wine_position": {
+          "name": "idx_slides_package_wine_position",
+          "columns": [
+            {
+              "expression": "package_wine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slides_global_position": {
+          "name": "idx_slides_global_position",
+          "columns": [
+            {
+              "expression": "package_wine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "global_position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slides_package_wine_id": {
+          "name": "idx_slides_package_wine_id",
+          "columns": [
+            {
+              "expression": "package_wine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slides_package_id": {
+          "name": "idx_slides_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slides_type": {
+          "name": "idx_slides_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slides_package_wine_id_package_wines_id_fk": {
+          "name": "slides_package_wine_id_package_wines_id_fk",
+          "tableFrom": "slides",
+          "tableTo": "package_wines",
+          "columnsFrom": [
+            "package_wine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slides_package_id_packages_id_fk": {
+          "name": "slides_package_id_packages_id_fk",
+          "tableFrom": "slides",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sommelier_chats": {
+      "name": "sommelier_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_summary_at": {
+          "name": "last_summary_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sommelier_chats_user": {
+          "name": "idx_sommelier_chats_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sommelier_chats_updated": {
+          "name": "idx_sommelier_chats_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sommelier_chats_user_id_users_id_fk": {
+          "name": "sommelier_chats_user_id_users_id_fk",
+          "tableFrom": "sommelier_chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sommelier_messages": {
+      "name": "sommelier_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_description": {
+          "name": "image_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sommelier_messages_chat": {
+          "name": "idx_sommelier_messages_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sommelier_messages_chat_created": {
+          "name": "idx_sommelier_messages_chat_created",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sommelier_messages_chat_id_sommelier_chats_id_fk": {
+          "name": "sommelier_messages_chat_id_sommelier_chats_id_fk",
+          "tableFrom": "sommelier_messages",
+          "tableTo": "sommelier_chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sommeliers": {
+      "name": "sommeliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sommeliers_email": {
+          "name": "idx_sommeliers_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sommeliers_email_unique": {
+          "name": "sommeliers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tastings": {
+      "name": "tastings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wine_name": {
+          "name": "wine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wine_region": {
+          "name": "wine_region",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wine_vintage": {
+          "name": "wine_vintage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grape_variety": {
+          "name": "grape_variety",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wine_type": {
+          "name": "wine_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasted_at": {
+          "name": "tasted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wine_characteristics": {
+          "name": "wine_characteristics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasting_mode": {
+          "name": "tasting_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tastings_user_id": {
+          "name": "idx_tastings_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tastings_tasted_at": {
+          "name": "idx_tastings_tasted_at",
+          "columns": [
+            {
+              "expression": "tasted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tastings_responses": {
+          "name": "idx_tastings_responses",
+          "columns": [
+            {
+              "expression": "responses",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tastings_user_id_users_id_fk": {
+          "name": "tastings_user_id_users_id_fk",
+          "tableFrom": "tastings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_journeys": {
+      "name": "user_journeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journey_id": {
+          "name": "journey_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_chapter": {
+          "name": "current_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "completed_chapters": {
+          "name": "completed_chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_journeys_user": {
+          "name": "idx_user_journeys_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_journeys_journey": {
+          "name": "idx_user_journeys_journey",
+          "columns": [
+            {
+              "expression": "journey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_journeys_user_id_users_id_fk": {
+          "name": "user_journeys_user_id_users_id_fk",
+          "tableFrom": "user_journeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_journeys_journey_id_journeys_id_fk": {
+          "name": "user_journeys_journey_id_journeys_id_fk",
+          "tableFrom": "user_journeys",
+          "tableTo": "journeys",
+          "columnsFrom": [
+            "journey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_journeys_user_id_journey_id_unique": {
+          "name": "user_journeys_user_id_journey_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "journey_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_taste_profiles": {
+      "name": "user_taste_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_data": {
+          "name": "profile_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthesized_at": {
+          "name": "synthesized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_taste_profiles_user_id_users_id_fk": {
+          "name": "user_taste_profiles_user_id_users_id_fk",
+          "tableFrom": "user_taste_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_taste_profiles_user_id_unique": {
+          "name": "user_taste_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tasting_level": {
+          "name": "tasting_level",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'intro'"
+        },
+        "tastings_completed": {
+          "name": "tastings_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level_up_prompt_eligible": {
+          "name": "level_up_prompt_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "wine_archetype": {
+          "name": "wine_archetype",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_data": {
+          "name": "onboarding_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wine_characteristics": {
+      "name": "wine_characteristics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scale_type": {
+          "name": "scale_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scale_min": {
+          "name": "scale_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scale_max": {
+          "name": "scale_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scale_labels": {
+          "name": "scale_labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wine_characteristics_category": {
+          "name": "idx_wine_characteristics_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wine_characteristics_name_unique": {
+          "name": "wine_characteristics_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wine_characteristics_cache": {
+      "name": "wine_characteristics_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wine_signature": {
+          "name": "wine_signature",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "characteristics": {
+          "name": "characteristics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wine_cache_signature": {
+          "name": "idx_wine_cache_signature",
+          "columns": [
+            {
+              "expression": "wine_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wine_characteristics_cache_wine_signature_unique": {
+          "name": "wine_characteristics_cache_wine_signature_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wine_signature"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wine_response_analytics": {
+      "name": "wine_response_analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "package_wine_id": {
+          "name": "package_wine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "characteristic_name": {
+          "name": "characteristic_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_value": {
+          "name": "expected_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_user_value": {
+          "name": "average_user_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accuracy_score": {
+          "name": "accuracy_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_count": {
+          "name": "response_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wine_analytics_wine_char": {
+          "name": "idx_wine_analytics_wine_char",
+          "columns": [
+            {
+              "expression": "package_wine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "characteristic_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wine_response_analytics_package_wine_id_package_wines_id_fk": {
+          "name": "wine_response_analytics_package_wine_id_package_wines_id_fk",
+          "tableFrom": "wine_response_analytics",
+          "tableTo": "package_wines",
+          "columnsFrom": [
+            "package_wine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1768429276356,
       "tag": "0003_superb_azazel",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1774038586056,
+      "tag": "0004_thankful_korg",
+      "breakpoints": true
     }
   ]
 }

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { db } from "../db";
-import { users, tastings, userJourneys, chapterCompletions, sessions, participants, journeys } from "@shared/schema";
-import { sql, count, eq, gte, and, desc, isNotNull } from "drizzle-orm";
+import { users, tastings, userJourneys, sessions, participants, journeys } from "@shared/schema";
+import { sql, count, eq, gte } from "drizzle-orm";
 
 export function registerAdminRoutes(app: Express) {
   console.log("📊 Registering admin engagement endpoints...");
@@ -27,7 +27,6 @@ export function registerAdminRoutes(app: Express) {
         recentUsersResult,
         activeJourneysResult,
         usersEnrolledResult,
-        chapterCompletionsResult,
         totalSessionsResult,
         totalParticipantsResult,
         sessionsThisMonthResult,
@@ -61,7 +60,6 @@ export function registerAdminRoutes(app: Express) {
         // Journey stats
         db.select({ count: count() }).from(journeys).where(eq(journeys.isPublished, true)),
         db.select({ count: count() }).from(userJourneys),
-        db.select({ count: count() }).from(chapterCompletions),
 
         // Session stats
         db.select({ count: count() }).from(sessions),
@@ -69,10 +67,18 @@ export function registerAdminRoutes(app: Express) {
         db.select({ count: count() }).from(sessions).where(gte(sessions.startedAt, startOfMonth)),
       ]);
 
-      const totalUsers = totalUsersResult[0]?.count ?? 0;
+      // chapter_completions table may not exist yet — query safely
+      let chapterCompletionsCount = 0;
+      try {
+        const result = await db.execute(sql`SELECT count(*)::int as count FROM chapter_completions`);
+        chapterCompletionsCount = (result as any[])[0]?.count ?? 0;
+      } catch {
+        // Table doesn't exist yet, that's fine
+      }
+
       const onboardingTotal = onboardingResult[0]?.total ?? 0;
       const onboardingCompleted = onboardingResult[0]?.completed ?? 0;
-      const onboardingRate = onboardingTotal > 0
+      const onboardingRate = Number(onboardingTotal) > 0
         ? Math.round((Number(onboardingCompleted) / Number(onboardingTotal)) * 100)
         : 0;
 
@@ -97,7 +103,7 @@ export function registerAdminRoutes(app: Express) {
         journeys: {
           activeJourneys: activeJourneysResult[0]?.count ?? 0,
           usersEnrolled: usersEnrolledResult[0]?.count ?? 0,
-          chapterCompletions: chapterCompletionsResult[0]?.count ?? 0,
+          chapterCompletions: chapterCompletionsCount,
         },
         sessions: {
           totalSessions: totalSessionsResult[0]?.count ?? 0,

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -43,18 +43,21 @@ export function registerAdminRoutes(app: Express) {
           completed: count(sql`CASE WHEN ${users.onboardingCompleted} = true THEN 1 END`),
         }).from(users),
 
-        // Recent users with tasting counts
+        // Recent users with actual tasting counts, sorted by most recent activity
         db.execute(sql`
           SELECT
             u.email,
             u.created_at,
-            u.tastings_completed,
+            (SELECT count(*) FROM tastings t WHERE t.user_id = u.id)::int as tastings_completed,
             u.tasting_level,
             u.onboarding_completed,
             (SELECT MAX(t.tasted_at) FROM tastings t WHERE t.user_id = u.id) as last_tasting_date
           FROM users u
-          ORDER BY u.created_at DESC
-          LIMIT 20
+          ORDER BY COALESCE(
+            (SELECT MAX(t.tasted_at) FROM tastings t WHERE t.user_id = u.id),
+            u.created_at
+          ) DESC
+          LIMIT 30
         `),
 
         // Journey stats

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -68,7 +68,8 @@ export function registerAdminRoutes(app: Express) {
             GREATEST(
               (SELECT MAX(t.tasted_at) FROM tastings t WHERE t.user_id = u.id),
               (SELECT MAX(p.created_at) FROM participants p WHERE p.email = u.email)
-            ) as last_tasting_date
+            ) as last_tasting_date,
+            u.last_seen_at
           FROM users u
           ORDER BY COALESCE(
             GREATEST(
@@ -132,6 +133,7 @@ export function registerAdminRoutes(app: Express) {
           lastTastingDate: row.last_tasting_date,
           tastingLevel: row.tasting_level,
           onboardingCompleted: row.onboarding_completed,
+          lastSeenAt: row.last_seen_at,
         })),
         journeys: {
           activeJourneys: activeJourneysResult[0]?.count ?? 0,

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -77,7 +77,6 @@ export function registerAdminRoutes(app: Express) {
             ),
             u.created_at
           ) DESC
-          LIMIT 30
         `),
 
         // Journey stats
@@ -148,6 +147,47 @@ export function registerAdminRoutes(app: Express) {
     } catch (error) {
       console.error("Error fetching engagement metrics:", error);
       res.status(500).json({ message: "Failed to fetch engagement metrics" });
+    }
+  });
+
+  // User detail: tasting history for a specific user
+  app.get("/api/admin/user/:email", async (req, res) => {
+    try {
+      const email = decodeURIComponent(req.params.email);
+
+      const [soloTastings, groupSessions] = await Promise.all([
+        // Solo tastings
+        db.execute(sql`
+          SELECT t.id, t.wine_name, t.wine_type, t.wine_region, t.tasted_at, t.tasting_mode,
+                 'solo' as source
+          FROM tastings t
+          JOIN users u ON u.id = t.user_id
+          WHERE u.email = ${email}
+          ORDER BY t.tasted_at DESC
+        `),
+        // Group sessions
+        db.execute(sql`
+          SELECT p.id, p.display_name, p.created_at, p.is_host,
+                 s.short_code, s.status as session_status,
+                 pkg.name as package_name,
+                 (SELECT count(*) FROM responses r WHERE r.participant_id = p.id)::int as responses_count,
+                 'group' as source
+          FROM participants p
+          JOIN sessions s ON s.id = p.session_id
+          LEFT JOIN packages pkg ON pkg.id = s.package_id
+          WHERE p.email = ${email}
+          ORDER BY p.created_at DESC
+        `),
+      ]);
+
+      res.json({
+        email,
+        soloTastings: soloTastings as any[],
+        groupSessions: groupSessions as any[],
+      });
+    } catch (error) {
+      console.error("Error fetching user detail:", error);
+      res.status(500).json({ message: "Failed to fetch user detail" });
     }
   });
 }

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -16,13 +16,17 @@ export function registerAdminRoutes(app: Express) {
       const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
 
       // Run all queries in parallel
+      // Total tastings = solo tastings + group session participations
       const [
         totalUsersResult,
         usersThisWeekResult,
         usersThisMonthResult,
-        totalTastingsResult,
-        tastingsThisWeekResult,
-        tastingsThisMonthResult,
+        soloTastingsResult,
+        soloTastingsThisWeekResult,
+        soloTastingsThisMonthResult,
+        groupTastingsResult,
+        groupTastingsThisWeekResult,
+        groupTastingsThisMonthResult,
         onboardingResult,
         recentUsersResult,
         activeJourneysResult,
@@ -31,30 +35,46 @@ export function registerAdminRoutes(app: Express) {
         totalParticipantsResult,
         sessionsThisMonthResult,
       ] = await Promise.all([
-        // Summary counts
+        // User counts
         db.select({ count: count() }).from(users),
         db.select({ count: count() }).from(users).where(gte(users.createdAt, startOfWeek)),
         db.select({ count: count() }).from(users).where(gte(users.createdAt, startOfMonth)),
+
+        // Solo tasting counts
         db.select({ count: count() }).from(tastings),
         db.select({ count: count() }).from(tastings).where(gte(tastings.tastedAt, startOfWeek)),
         db.select({ count: count() }).from(tastings).where(gte(tastings.tastedAt, startOfMonth)),
+
+        // Group tasting counts (each participant in a session = 1 tasting)
+        db.select({ count: count() }).from(participants),
+        db.select({ count: count() }).from(participants).where(gte(participants.createdAt, startOfWeek)),
+        db.select({ count: count() }).from(participants).where(gte(participants.createdAt, startOfMonth)),
+
+        // Onboarding
         db.select({
           total: count(),
           completed: count(sql`CASE WHEN ${users.onboardingCompleted} = true THEN 1 END`),
         }).from(users),
 
-        // Recent users with actual tasting counts, sorted by most recent activity
+        // Recent users: count solo + group tastings, sort by most recent activity
         db.execute(sql`
           SELECT
             u.email,
             u.created_at,
-            (SELECT count(*) FROM tastings t WHERE t.user_id = u.id)::int as tastings_completed,
+            (SELECT count(*) FROM tastings t WHERE t.user_id = u.id)::int as solo_tastings,
+            (SELECT count(*) FROM participants p WHERE p.email = u.email)::int as group_tastings,
             u.tasting_level,
             u.onboarding_completed,
-            (SELECT MAX(t.tasted_at) FROM tastings t WHERE t.user_id = u.id) as last_tasting_date
+            GREATEST(
+              (SELECT MAX(t.tasted_at) FROM tastings t WHERE t.user_id = u.id),
+              (SELECT MAX(p.created_at) FROM participants p WHERE p.email = u.email)
+            ) as last_tasting_date
           FROM users u
           ORDER BY COALESCE(
-            (SELECT MAX(t.tasted_at) FROM tastings t WHERE t.user_id = u.id),
+            GREATEST(
+              (SELECT MAX(t.tasted_at) FROM tastings t WHERE t.user_id = u.id),
+              (SELECT MAX(p.created_at) FROM participants p WHERE p.email = u.email)
+            ),
             u.created_at
           ) DESC
           LIMIT 30
@@ -85,20 +105,31 @@ export function registerAdminRoutes(app: Express) {
         ? Math.round((Number(onboardingCompleted) / Number(onboardingTotal)) * 100)
         : 0;
 
+      const soloTotal = Number(soloTastingsResult[0]?.count ?? 0);
+      const groupTotal = Number(groupTastingsResult[0]?.count ?? 0);
+      const soloWeek = Number(soloTastingsThisWeekResult[0]?.count ?? 0);
+      const groupWeek = Number(groupTastingsThisWeekResult[0]?.count ?? 0);
+      const soloMonth = Number(soloTastingsThisMonthResult[0]?.count ?? 0);
+      const groupMonth = Number(groupTastingsThisMonthResult[0]?.count ?? 0);
+
       res.json({
         summary: {
           totalUsers: totalUsersResult[0]?.count ?? 0,
           usersThisWeek: usersThisWeekResult[0]?.count ?? 0,
           usersThisMonth: usersThisMonthResult[0]?.count ?? 0,
-          totalTastings: totalTastingsResult[0]?.count ?? 0,
-          tastingsThisWeek: tastingsThisWeekResult[0]?.count ?? 0,
-          tastingsThisMonth: tastingsThisMonthResult[0]?.count ?? 0,
+          totalTastings: soloTotal + groupTotal,
+          tastingsThisWeek: soloWeek + groupWeek,
+          tastingsThisMonth: soloMonth + groupMonth,
+          soloTastings: soloTotal,
+          groupTastings: groupTotal,
           onboardingCompletionRate: onboardingRate,
         },
         recentUsers: (recentUsersResult as any[]).map((row: any) => ({
           email: row.email,
           createdAt: row.created_at,
-          tastingsCompleted: row.tastings_completed,
+          soloTastings: row.solo_tastings,
+          groupTastings: row.group_tastings,
+          tastingsCompleted: Number(row.solo_tastings) + Number(row.group_tastings),
           lastTastingDate: row.last_tasting_date,
           tastingLevel: row.tasting_level,
           onboardingCompleted: row.onboarding_completed,

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -99,11 +99,24 @@ async function cleanupOldAttempts(): Promise<void> {
 /**
  * Middleware to require authentication
  */
+const lastSeenCache = new Map<number, number>(); // userId -> timestamp
+const LAST_SEEN_THROTTLE_MS = 5 * 60 * 1000; // 5 minutes
+
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
   if (!req.session?.userId) {
     res.status(401).json({ error: "Authentication required" });
     return;
   }
+
+  // Throttled update of lastSeenAt
+  const userId = req.session.userId;
+  const now = Date.now();
+  const lastUpdate = lastSeenCache.get(userId) ?? 0;
+  if (now - lastUpdate > LAST_SEEN_THROTTLE_MS) {
+    lastSeenCache.set(userId, now);
+    db.update(users).set({ lastSeenAt: sql`now()` }).where(eq(users.id, userId)).execute().catch(() => {});
+  }
+
   next();
 }
 

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -697,19 +697,19 @@ export function registerDashboardRoutes(app: Express) {
         .orderBy(desc(tastings.tastedAt))
         .limit(5);
 
-      // Get tasting stats
-      const statsResult = await db
-        .select({
+      // Get tasting stats (solo + group in parallel)
+      const [statsResult, unifiedStats, activeJourneys] = await Promise.all([
+        db.select({
           totalTastings: sql<number>`count(*)`,
           avgOverallRating: sql<number>`avg((responses->'overall'->>'rating')::numeric)`
         })
         .from(tastings)
-        .where(eq(tastings.userId, userId));
+        .where(eq(tastings.userId, userId)),
+        storage.getUnifiedTastingStats(userEmail),
+        storage.getUserActiveJourneys(userEmail),
+      ]);
 
       const stats = statsResult[0] || { totalTastings: 0, avgOverallRating: null };
-
-      // Get active journeys count
-      const activeJourneys = await storage.getUserActiveJourneys(userEmail);
 
       return res.json({
         user: {
@@ -722,6 +722,8 @@ export function registerDashboardRoutes(app: Express) {
         },
         stats: {
           totalSoloTastings: Number(stats.totalTastings),
+          totalGroupTastings: unifiedStats.group,
+          totalCombinedTastings: unifiedStats.total,
           averageRating: stats.avgOverallRating ? Number(stats.avgOverallRating).toFixed(1) : null,
           activeJourneys: activeJourneys.length
         },
@@ -734,7 +736,7 @@ export function registerDashboardRoutes(app: Express) {
         links: {
           // Agent-native: provide links for follow-up actions
           fullDashboard: `/api/dashboard/${encodeURIComponent(userEmail)}`,
-          preferences: '/api/solo/preferences',
+          preferences: `/api/dashboard/${encodeURIComponent(userEmail)}/preferences`,
           recommendations: '/api/solo/recommendations',
           levelStatus: '/api/solo/level',
           tastings: '/api/solo/tastings'

--- a/server/services/tasteProfileService.ts
+++ b/server/services/tasteProfileService.ts
@@ -84,12 +84,20 @@ const GROUP_CATEGORY_TO_TRAIT: ReadonlyMap<string, TraitName> = new Map([
   ['sweetness', 'sweetness'],
 ]);
 
-function mapCategoryToTrait(category: string): TraitName | null {
-  const trait = GROUP_CATEGORY_TO_TRAIT.get(category.toLowerCase()) ?? null;
-  if (!trait && category) {
-    console.warn(`[TasteProfile] Unmapped group category: "${category}"`);
+function mapCategoryToTrait(category: string | null, title: string | null): TraitName | null {
+  if (category) {
+    const trait = GROUP_CATEGORY_TO_TRAIT.get(category.toLowerCase()) ?? null;
+    if (trait) return trait;
   }
-  return trait;
+  // Fallback: extract trait from slide title text (older packages lack category)
+  if (title) {
+    const t = title.toLowerCase();
+    if (t.includes('body')) return 'body';
+    if (t.includes('tannin')) return 'tannins';
+    if (t.includes('acidity')) return 'acidity';
+    if (t.includes('sweetness') || t.includes('sweet')) return 'sweetness';
+  }
+  return null;
 }
 
 function normalizeToFivePointScale(value: number, scaleMax: number): number {
@@ -108,7 +116,7 @@ function normalizeGroupResponses(
     if (row.questionType !== 'scale') continue;
     if (row.selectedScore == null || row.packageWineId == null) continue;
 
-    const trait = mapCategoryToTrait(row.category ?? '');
+    const trait = mapCategoryToTrait(row.category, row.title);
     if (!trait) continue;
 
     signals.push({

--- a/server/services/tasteProfileService.ts
+++ b/server/services/tasteProfileService.ts
@@ -9,6 +9,9 @@ import { z } from 'zod';
 import { zodResponseFormat } from 'openai/helpers/zod';
 import { getOpenAIClient } from '../lib/openai';
 import { storage } from '../storage';
+import { db } from '../db';
+import { users } from '@shared/schema';
+import { eq } from 'drizzle-orm';
 import { sanitizeForPrompt } from '../lib/sanitize';
 import type { TasteProfile, TraitName, TraitScore, RankedItem, WineCharacteristicsData } from '@shared/schema';
 
@@ -43,9 +46,17 @@ interface AggregatedTraitStats {
   count: number;
 }
 
+interface GroupTraitSignal {
+  trait: TraitName;
+  value: number;         // normalized to 1-5
+  packageWineId: string;
+  answeredAt: Date;
+}
+
 interface ProfileSignalSummary {
   explicitTraits: Record<TraitName, AggregatedTraitStats>;
   implicitTraits: Record<TraitName, AggregatedTraitStats>;
+  groupTraits: Record<TraitName, AggregatedTraitStats>;
   avgEnjoyment: number | null;
   wantMoreRatio: number | null;
   wouldBuyAgain: { yes: number; maybe: number; no: number };
@@ -58,7 +69,57 @@ interface ProfileSignalSummary {
   totalTastings: number;
   fullTastings: number;
   quickRates: number;
+  groupTastings: number;
   dateRange: { oldest: string; newest: string };
+}
+
+// ============================================
+// GROUP SIGNAL NORMALIZATION
+// ============================================
+
+const GROUP_CATEGORY_TO_TRAIT: ReadonlyMap<string, TraitName> = new Map([
+  ['body', 'body'],
+  ['tannins', 'tannins'],
+  ['acidity', 'acidity'],
+  ['sweetness', 'sweetness'],
+]);
+
+function mapCategoryToTrait(category: string): TraitName | null {
+  const trait = GROUP_CATEGORY_TO_TRAIT.get(category.toLowerCase()) ?? null;
+  if (!trait && category) {
+    console.warn(`[TasteProfile] Unmapped group category: "${category}"`);
+  }
+  return trait;
+}
+
+function normalizeToFivePointScale(value: number, scaleMax: number): number {
+  if (scaleMax <= 1) return 3; // degenerate scale — return midpoint
+  const clamped = Math.max(1, Math.min(value, scaleMax));
+  if (scaleMax === 5) return clamped;
+  return 1 + ((clamped - 1) / (scaleMax - 1)) * 4;
+}
+
+function normalizeGroupResponses(
+  rawRows: Awaited<ReturnType<typeof storage.getGroupResponsesForProfile>>
+): GroupTraitSignal[] {
+  const signals: GroupTraitSignal[] = [];
+
+  for (const row of rawRows) {
+    if (row.questionType !== 'scale') continue;
+    if (row.selectedScore == null || row.packageWineId == null) continue;
+
+    const trait = mapCategoryToTrait(row.category ?? '');
+    if (!trait) continue;
+
+    signals.push({
+      trait,
+      value: normalizeToFivePointScale(row.selectedScore, row.scaleMax ?? 10),
+      packageWineId: row.packageWineId,
+      answeredAt: row.answeredAt ?? new Date(),
+    });
+  }
+
+  return signals;
 }
 
 // ============================================
@@ -107,7 +168,10 @@ export async function getOrSynthesizeProfile(userId: number): Promise<{
 // SIGNAL AGGREGATION
 // ============================================
 
-function buildSignalSummary(signals: Awaited<ReturnType<typeof storage.getTastingSignalsForProfile>>): ProfileSignalSummary {
+function buildSignalSummary(
+  signals: Awaited<ReturnType<typeof storage.getTastingSignalsForProfile>>,
+  groupSignals: GroupTraitSignal[] = [],
+): ProfileSignalSummary {
   const { fullTastings, quickRatesWithCharacteristics } = signals;
 
   // Explicit trait stats from full tastings
@@ -165,6 +229,29 @@ function buildSignalSummary(signals: Awaited<ReturnType<typeof storage.getTastin
       implicitTraits[trait].mean = implicitSums[trait] / implicitTraits[trait].count;
     }
   }
+
+  // Group trait stats (from group tasting responses)
+  const groupTraits: Record<TraitName, AggregatedTraitStats> = {
+    sweetness: { mean: 0, count: 0 },
+    acidity: { mean: 0, count: 0 },
+    tannins: { mean: 0, count: 0 },
+    body: { mean: 0, count: 0 },
+  };
+
+  const groupSums: Record<TraitName, number> = { sweetness: 0, acidity: 0, tannins: 0, body: 0 };
+
+  for (const gs of groupSignals) {
+    groupSums[gs.trait] += gs.value;
+    groupTraits[gs.trait].count += 1;
+  }
+
+  for (const trait of traitNames) {
+    if (groupTraits[trait].count > 0) {
+      groupTraits[trait].mean = groupSums[trait] / groupTraits[trait].count;
+    }
+  }
+
+  const groupWineCount = new Set(groupSignals.map(s => s.packageWineId)).size;
 
   // Preference beat aggregation (enjoyment + wantMore)
   let enjoymentSum = 0, enjoymentCount = 0;
@@ -250,9 +337,16 @@ function buildSignalSummary(signals: Awaited<ReturnType<typeof storage.getTastin
   const oldest = allDates.length > 0 ? new Date(Math.min(...allDates.map(d => d.getTime()))).toISOString() : '';
   const newest = allDates.length > 0 ? new Date(Math.max(...allDates.map(d => d.getTime()))).toISOString() : '';
 
+  // Include group dates in date range
+  const groupDates = groupSignals.map(s => s.answeredAt);
+  const allDatesIncludingGroup = [...allDates, ...groupDates];
+  const oldestAll = allDatesIncludingGroup.length > 0 ? new Date(Math.min(...allDatesIncludingGroup.map(d => d.getTime()))).toISOString() : oldest;
+  const newestAll = allDatesIncludingGroup.length > 0 ? new Date(Math.max(...allDatesIncludingGroup.map(d => d.getTime()))).toISOString() : newest;
+
   return {
     explicitTraits,
     implicitTraits,
+    groupTraits,
     avgEnjoyment: enjoymentCount > 0 ? enjoymentSum / enjoymentCount : null,
     wantMoreRatio: wantMoreTotal > 0 ? wantMoreYes / wantMoreTotal : null,
     wouldBuyAgain,
@@ -262,10 +356,11 @@ function buildSignalSummary(signals: Awaited<ReturnType<typeof storage.getTastin
     ratingsByRegion,
     ratingsByGrape,
     recentNotes: recentNotes.slice(0, 10),
-    totalTastings: fullTastings.length + quickRatesWithCharacteristics.length,
+    totalTastings: fullTastings.length + quickRatesWithCharacteristics.length + groupWineCount,
     fullTastings: fullTastings.length,
     quickRates: quickRatesWithCharacteristics.length,
-    dateRange: { oldest, newest },
+    groupTastings: groupWineCount,
+    dateRange: { oldest: oldestAll, newest: newestAll },
   };
 }
 
@@ -347,9 +442,9 @@ function computeTopItems(ratings: Record<string, { count: number; mean: number }
     .slice(0, 5);
 }
 
-function computeConfidenceLevel(fullCount: number, quickCount: number): 'low' | 'medium' | 'high' {
-  // Effective weight: full=1.0, quick=0.4
-  const effectiveWeight = fullCount * 1.0 + quickCount * 0.4;
+function computeConfidenceLevel(fullCount: number, quickCount: number, groupCount: number = 0): 'low' | 'medium' | 'high' {
+  // Effective weight: full=1.0, group=1.0, quick=0.4
+  const effectiveWeight = fullCount * 1.0 + groupCount * 1.0 + quickCount * 0.4;
   if (effectiveWeight >= 6) return 'high';
   if (effectiveWeight >= 3) return 'medium';
   return 'low';
@@ -374,10 +469,28 @@ async function synthesizeProfile(
   fingerprint: string,
   previousProfile: TasteProfile | null,
 ): Promise<TasteProfile> {
+  // Fetch solo signals
   const rawSignals = await storage.getTastingSignalsForProfile(userId);
-  const signals = buildSignalSummary(rawSignals);
+
+  // Fetch group signals (via user's email)
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: { email: true },
+  });
+  let groupSignals: GroupTraitSignal[] = [];
+  if (user?.email) {
+    const rawGroupRows = await storage.getGroupResponsesForProfile(user.email);
+    groupSignals = normalizeGroupResponses(rawGroupRows);
+  }
+
+  const signals = buildSignalSummary(rawSignals, groupSignals);
 
   const openaiClient = getOpenAIClient();
+
+  // Add group context to GPT prompt when group data is present
+  const groupContext = signals.groupTastings > 0
+    ? `\n\nNote: Some trait data comes from group tasting sessions, which provide per-trait ratings but not flavor/aroma details. ${signals.groupTastings} wines were tasted in group settings.`
+    : '';
 
   let gptOutput: GptProfileOutput;
 
@@ -387,12 +500,13 @@ async function synthesizeProfile(
       const completion = await openaiClient.beta.chat.completions.parse({
         model: 'gpt-5.2',
         messages: [
-          { role: 'system', content: SYNTHESIS_PROMPT },
+          { role: 'system', content: SYNTHESIS_PROMPT + groupContext },
           {
             role: 'user',
             content: JSON.stringify({
               explicitTraits: signals.explicitTraits,
               implicitTraits: signals.implicitTraits,
+              groupTraits: signals.groupTraits,
               avgEnjoyment: signals.avgEnjoyment,
               wantMoreRatio: signals.wantMoreRatio,
               wouldBuyAgain: signals.wouldBuyAgain,
@@ -405,6 +519,7 @@ async function synthesizeProfile(
               totalTastings: signals.totalTastings,
               fullTastings: signals.fullTastings,
               quickRates: signals.quickRates,
+              groupTastings: signals.groupTastings,
               previousStyleIdentity: previousProfile?.styleIdentity ?? null,
             }),
           },
@@ -429,9 +544,6 @@ async function synthesizeProfile(
   }
 
   // Merge GPT output with deterministic fields
-  const allTastings = [...rawSignals.fullTastings, ...rawSignals.quickRatesWithCharacteristics];
-  const allDates = allTastings.map(t => t.tastedAt);
-
   const profile: TasteProfile = {
     traits: gptOutput.traits,
     styleIdentity: gptOutput.styleIdentity,
@@ -444,8 +556,9 @@ async function synthesizeProfile(
       totalTastings: signals.totalTastings,
       fullTastings: signals.fullTastings,
       quickRates: signals.quickRates,
-      oldestTasting: allDates.length > 0 ? new Date(Math.min(...allDates.map(d => d.getTime()))).toISOString() : '',
-      newestTasting: allDates.length > 0 ? new Date(Math.max(...allDates.map(d => d.getTime()))).toISOString() : '',
+      groupTastings: signals.groupTastings,
+      oldestTasting: signals.dateRange.oldest,
+      newestTasting: signals.dateRange.newest,
     },
     synthesizedAt: new Date().toISOString(),
   };
@@ -453,7 +566,7 @@ async function synthesizeProfile(
   // AWAIT the write (institutional learning: never fire-and-forget)
   await storage.upsertTasteProfile(userId, profile, fingerprint);
 
-  console.log(`[TasteProfile] Synthesized profile for user ${userId}: ${signals.fullTastings} full + ${signals.quickRates} quick rates`);
+  console.log(`[TasteProfile] Synthesized profile for user ${userId}: ${signals.fullTastings} full + ${signals.quickRates} quick + ${signals.groupTastings} group`);
 
   return profile;
 }
@@ -465,13 +578,14 @@ function buildDeterministicFallback(signals: ProfileSignalSummary): GptProfileOu
   for (const trait of traitNames) {
     const explicit = signals.explicitTraits[trait];
     const implicit = signals.implicitTraits[trait];
+    const group = signals.groupTraits[trait];
 
-    // Weighted average: explicit=1.0, implicit=0.5
-    const totalWeight = explicit.count * 1.0 + implicit.count * 0.5;
-    const weightedSum = explicit.mean * explicit.count * 1.0 + implicit.mean * implicit.count * 0.5;
+    // Weighted average: explicit=1.0, group=1.0, implicit=0.5
+    const totalWeight = explicit.count * 1.0 + group.count * 1.0 + implicit.count * 0.5;
+    const weightedSum = explicit.mean * explicit.count * 1.0 + group.mean * group.count * 1.0 + implicit.mean * implicit.count * 0.5;
     const value = totalWeight > 0 ? weightedSum / totalWeight : 3.0;
 
-    const totalDataPoints = explicit.count + implicit.count;
+    const totalDataPoints = explicit.count + group.count + implicit.count;
     let confidence = 0;
     if (totalDataPoints >= 10) confidence = 1.0;
     else if (totalDataPoints >= 6) confidence = 0.8;
@@ -486,6 +600,6 @@ function buildDeterministicFallback(signals: ProfileSignalSummary): GptProfileOu
     styleIdentity: signals.totalTastings < 3
       ? 'Your taste profile is just getting started. Keep tasting to unlock personalized insights!'
       : 'Your taste profile is building. A few more tastings will reveal your wine identity.',
-    confidence: computeConfidenceLevel(signals.fullTastings, signals.quickRates),
+    confidence: computeConfidenceLevel(signals.fullTastings, signals.quickRates, signals.groupTastings),
   };
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -6740,6 +6740,43 @@ export class DatabaseStorage implements IStorage {
     };
   }
 
+  // Group responses for taste profile synthesis (raw rows — normalization in service layer)
+  async getGroupResponsesForProfile(email: string): Promise<Array<{
+    responseId: string;
+    selectedScore: number | null;
+    answeredAt: Date | null;
+    category: string | null;
+    scaleMax: number | null;
+    questionType: string | null;
+    packageWineId: string | null;
+  }>> {
+    const normalizedEmail = email.toLowerCase();
+
+    const rows = await db
+      .select({
+        responseId: responses.id,
+        selectedScore: sql<number | null>`(${responses.answerJson}->>'selectedScore')::numeric`,
+        answeredAt: responses.answeredAt,
+        category: sql<string | null>`${slides.payloadJson}->>'category'`,
+        scaleMax: sql<number | null>`(${slides.payloadJson}->>'scale_max')::int`,
+        questionType: sql<string | null>`${slides.payloadJson}->>'question_type'`,
+        packageWineId: slides.packageWineId,
+      })
+      .from(responses)
+      .innerJoin(slides, eq(responses.slideId, slides.id))
+      .innerJoin(participants, eq(responses.participantId, participants.id))
+      .where(
+        and(
+          sql`LOWER(${participants.email}) = ${normalizedEmail}`,
+          eq(slides.type, 'question'),
+        )
+      )
+      .orderBy(desc(responses.answeredAt))
+      .limit(500);
+
+    return rows;
+  }
+
   // AI Response Cache methods
   async getTastingFingerprint(email: string): Promise<string> {
     // Solo tasting stats

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -4880,11 +4880,17 @@ export class DatabaseStorage implements IStorage {
     const participantIds = userParticipants.map(p => p.id);
 
     // Query scale responses by JOINing through slides for category + score
+    // answer_json is a bare number in production; scale_max has both snake_case and camelCase
     const scaleRows = await db
       .select({
         category: sql<string>`${slides.payloadJson}->>'category'`,
-        scaleMax: sql<string>`${slides.payloadJson}->>'scale_max'`,
-        score: sql<string>`${responses.answerJson}->>'selectedScore'`,
+        title: sql<string>`${slides.payloadJson}->>'title'`,
+        scaleMax: sql<string>`COALESCE(${slides.payloadJson}->>'scale_max', ${slides.payloadJson}->>'scaleMax')`,
+        score: sql<string>`
+          CASE WHEN jsonb_typeof(${responses.answerJson}) = 'number'
+               THEN ${responses.answerJson}::text
+               ELSE ${responses.answerJson}->>'selectedScore'
+          END`,
       })
       .from(responses)
       .innerJoin(slides, eq(responses.slideId, slides.id))
@@ -4892,7 +4898,10 @@ export class DatabaseStorage implements IStorage {
         and(
           inArray(responses.participantId, participantIds),
           sql`${slides.payloadJson}->>'question_type' = 'scale'`,
-          isNotNull(sql`${responses.answerJson}->>'selectedScore'`),
+          sql`CASE WHEN jsonb_typeof(${responses.answerJson}) = 'number'
+               THEN ${responses.answerJson}::text
+               ELSE ${responses.answerJson}->>'selectedScore'
+          END IS NOT NULL`,
         )
       );
 
@@ -4906,8 +4915,17 @@ export class DatabaseStorage implements IStorage {
     };
 
     for (const row of scaleRows) {
+      // Try category first, then extract from title text as fallback
+      let trait: string | undefined;
       const category = (row.category || '').toLowerCase();
-      const trait = CATEGORY_TO_TRAIT[category];
+      trait = CATEGORY_TO_TRAIT[category];
+      if (!trait && row.title) {
+        const titleLower = row.title.toLowerCase();
+        if (titleLower.includes('body')) trait = 'body';
+        else if (titleLower.includes('tannin')) trait = 'tannins';
+        else if (titleLower.includes('acidity')) trait = 'acidity';
+        else if (titleLower.includes('sweetness') || titleLower.includes('sweet')) trait = 'sweetness';
+      }
       if (!trait) continue;
 
       const score = Number(row.score);
@@ -6759,19 +6777,31 @@ export class DatabaseStorage implements IStorage {
     selectedScore: number | null;
     answeredAt: Date | null;
     category: string | null;
+    title: string | null;
     scaleMax: number | null;
     questionType: string | null;
     packageWineId: string | null;
   }>> {
     const normalizedEmail = email.toLowerCase();
 
+    // answer_json is a bare number (not {selectedScore: N}) in production
+    // scale_max exists as both snake_case and camelCase depending on package age
+    // category is null on older packages — title is included for fallback trait extraction
     const rows = await db
       .select({
         responseId: responses.id,
-        selectedScore: sql<number | null>`(${responses.answerJson}->>'selectedScore')::numeric`,
+        selectedScore: sql<number | null>`
+          CASE WHEN jsonb_typeof(${responses.answerJson}) = 'number'
+               THEN (${responses.answerJson}::text)::numeric
+               ELSE (${responses.answerJson}->>'selectedScore')::numeric
+          END`,
         answeredAt: responses.answeredAt,
         category: sql<string | null>`${slides.payloadJson}->>'category'`,
-        scaleMax: sql<number | null>`(${slides.payloadJson}->>'scale_max')::int`,
+        title: sql<string | null>`${slides.payloadJson}->>'title'`,
+        scaleMax: sql<number | null>`COALESCE(
+          (${slides.payloadJson}->>'scale_max')::int,
+          (${slides.payloadJson}->>'scaleMax')::int
+        )`,
         questionType: sql<string | null>`${slides.payloadJson}->>'question_type'`,
         packageWineId: slides.packageWineId,
       })

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -4746,8 +4746,9 @@ export class DatabaseStorage implements IStorage {
 
   // User Dashboard
   async getAllParticipantsByEmail(email: string): Promise<Participant[]> {
+    const normalizedEmail = email.toLowerCase();
     // Check memo cache (5s TTL)
-    const cached = this.participantMemo.get(email);
+    const cached = this.participantMemo.get(normalizedEmail);
     if (cached && (Date.now() - cached.timestamp) < DatabaseStorage.PARTICIPANT_MEMO_TTL_MS) {
       return cached.data;
     }
@@ -4755,17 +4756,17 @@ export class DatabaseStorage implements IStorage {
     const result = await db
       .select()
       .from(participants)
-      .where(eq(participants.email, email));
+      .where(sql`LOWER(${participants.email}) = ${normalizedEmail}`);
 
     // Cap at 200 entries — evict oldest (FIFO via Map insertion order)
-    if (this.participantMemo.size >= 200 && !this.participantMemo.has(email)) {
+    if (this.participantMemo.size >= 200 && !this.participantMemo.has(normalizedEmail)) {
       const oldestKey = this.participantMemo.keys().next().value;
       if (oldestKey !== undefined) {
         this.participantMemo.delete(oldestKey);
       }
     }
 
-    this.participantMemo.set(email, { data: result, timestamp: Date.now() });
+    this.participantMemo.set(normalizedEmail, { data: result, timestamp: Date.now() });
     return result;
   }
 
@@ -4862,6 +4863,7 @@ export class DatabaseStorage implements IStorage {
   }
 
   // Sprint 4.1: Get group tasting preferences for unified dashboard
+  // Fixed: JOIN through slides to read payloadJson.category + answerJson.selectedScore
   async getGroupTastingPreferences(email: string): Promise<{
     sweetness: number | null;
     acidity: number | null;
@@ -4869,7 +4871,6 @@ export class DatabaseStorage implements IStorage {
     body: number | null;
     count: number;
   }> {
-    // Get all participant records for this email
     const userParticipants = await this.getAllParticipantsByEmail(email);
 
     if (userParticipants.length === 0) {
@@ -4878,59 +4879,59 @@ export class DatabaseStorage implements IStorage {
 
     const participantIds = userParticipants.map(p => p.id);
 
-    // Query responses using drizzle's inArray for proper array handling
-    const responseRows = await db
+    // Query scale responses by JOINing through slides for category + score
+    const scaleRows = await db
       .select({
-        sweetness: sql<string>`answer_json->>'sweetness'`,
-        acidity: sql<string>`answer_json->>'acidity'`,
-        tannins: sql<string>`answer_json->>'tannins'`,
-        body: sql<string>`answer_json->>'body'`,
+        category: sql<string>`${slides.payloadJson}->>'category'`,
+        scaleMax: sql<string>`${slides.payloadJson}->>'scale_max'`,
+        score: sql<string>`${responses.answerJson}->>'selectedScore'`,
       })
       .from(responses)
-      .where(inArray(responses.participantId, participantIds));
+      .innerJoin(slides, eq(responses.slideId, slides.id))
+      .where(
+        and(
+          inArray(responses.participantId, participantIds),
+          sql`${slides.payloadJson}->>'question_type' = 'scale'`,
+          isNotNull(sql`${responses.answerJson}->>'selectedScore'`),
+        )
+      );
 
-    // Calculate averages manually
-    let sweetnessSum = 0, sweetnessCount = 0;
-    let aciditySum = 0, acidityCount = 0;
-    let tanninsSum = 0, tanninsCount = 0;
-    let bodySum = 0, bodyCount = 0;
+    // Map categories to traits and normalize scales
+    const CATEGORY_TO_TRAIT: Record<string, string> = {
+      body: 'body', tannins: 'tannins', acidity: 'acidity', sweetness: 'sweetness',
+    };
 
-    for (const row of responseRows) {
-      if (row.sweetness) { sweetnessSum += Number(row.sweetness); sweetnessCount++; }
-      if (row.acidity) { aciditySum += Number(row.acidity); acidityCount++; }
-      if (row.tannins) { tanninsSum += Number(row.tannins); tanninsCount++; }
-      if (row.body) { bodySum += Number(row.body); bodyCount++; }
+    const traitAccum: Record<string, number[]> = {
+      sweetness: [], acidity: [], tannins: [], body: [],
+    };
+
+    for (const row of scaleRows) {
+      const category = (row.category || '').toLowerCase();
+      const trait = CATEGORY_TO_TRAIT[category];
+      if (!trait) continue;
+
+      const score = Number(row.score);
+      const scaleMax = Number(row.scaleMax) || 10;
+      if (isNaN(score) || score < 1) continue;
+
+      // Normalize to 1-5 scale
+      const clamped = Math.max(1, Math.min(score, scaleMax));
+      const normalized = scaleMax <= 1 ? 3 : scaleMax === 5 ? clamped : 1 + ((clamped - 1) / (scaleMax - 1)) * 4;
+      traitAccum[trait].push(normalized);
     }
 
-    const result = [{
-      sweetness: sweetnessCount > 0 ? sweetnessSum / sweetnessCount : null,
-      acidity: acidityCount > 0 ? aciditySum / acidityCount : null,
-      tannins: tanninsCount > 0 ? tanninsSum / tanninsCount : null,
-      body: bodyCount > 0 ? bodySum / bodyCount : null,
-      count: Math.max(sweetnessCount, acidityCount, tanninsCount, bodyCount)
-    }];
-
-    const row = Array.isArray(result) ? result[0] : (result as any).rows?.[0];
-
-    // If no explicit taste data, try alternative field paths
-    if (!row?.sweetness && !row?.acidity && !row?.tannins && !row?.body) {
-      // Fallback: count unique sessions as tastings
-      const uniqueSessions = new Set(userParticipants.map(p => p.sessionId).filter(Boolean));
-      return {
-        sweetness: null,
-        acidity: null,
-        tannins: null,
-        body: null,
-        count: uniqueSessions.size
-      };
-    }
+    const avg = (arr: number[]) => arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : null;
+    const totalResponses = Math.max(
+      traitAccum.sweetness.length, traitAccum.acidity.length,
+      traitAccum.tannins.length, traitAccum.body.length,
+    );
 
     return {
-      sweetness: row?.sweetness ? Number(row.sweetness) : null,
-      acidity: row?.acidity ? Number(row.acidity) : null,
-      tannins: row?.tannins ? Number(row.tannins) : null,
-      body: row?.body ? Number(row.body) : null,
-      count: row?.count ? Number(row.count) : 0
+      sweetness: avg(traitAccum.sweetness),
+      acidity: avg(traitAccum.acidity),
+      tannins: avg(traitAccum.tannins),
+      body: avg(traitAccum.body),
+      count: totalResponses > 0 ? totalResponses : new Set(userParticipants.map(p => p.sessionId).filter(Boolean)).size,
     };
   }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -6646,22 +6646,35 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getProfileFingerprint(userId: number): Promise<string> {
-    // Hash tasting IDs + updatedAt for content-aware fingerprint
-    const result = await db
-      .select({
-        id: tastings.id,
-        updatedAt: tastings.updatedAt,
-      })
-      .from(tastings)
-      .where(eq(tastings.userId, userId))
-      .orderBy(tastings.id);
+    // Fetch solo and user email in parallel
+    const [soloResult, user] = await Promise.all([
+      db.select({ id: tastings.id, updatedAt: tastings.updatedAt })
+        .from(tastings).where(eq(tastings.userId, userId)).orderBy(tastings.id),
+      db.query.users.findFirst({
+        where: eq(users.id, userId),
+        columns: { email: true },
+      }),
+    ]);
 
-    if (result.length === 0) return 'empty';
+    // Fetch group response IDs if user has email
+    let groupContent = '';
+    if (user?.email) {
+      const normalizedEmail = user.email.toLowerCase();
+      const groupResult = await db
+        .select({ id: responses.id, answeredAt: responses.answeredAt })
+        .from(responses)
+        .innerJoin(participants, eq(responses.participantId, participants.id))
+        .where(sql`LOWER(${participants.email}) = ${normalizedEmail}`)
+        .orderBy(responses.id);
 
-    const content = result
-      .map(t => `${t.id}:${t.updatedAt?.getTime() ?? 0}`)
-      .join(',');
-    return crypto.createHash('sha256').update(content).digest('hex').slice(0, 16);
+      groupContent = groupResult.map(r => `g${r.id}:${r.answeredAt?.getTime() ?? 0}`).join(',');
+    }
+
+    const soloContent = soloResult.map(t => `${t.id}:${t.updatedAt?.getTime() ?? 0}`).join(',');
+    const combined = `${soloContent}|${groupContent}`;
+
+    if (!soloContent && !groupContent) return 'empty';
+    return crypto.createHash('sha256').update(combined).digest('hex').slice(0, 16);
   }
 
   async getTastingSignalsForProfile(userId: number): Promise<{

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1256,6 +1256,7 @@ export interface TasteProfile {
     totalTastings: number;
     fullTastings: number;
     quickRates: number;
+    groupTastings?: number;
     oldestTasting: string;
     newestTasting: string;
   };

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -126,7 +126,8 @@ export const slides = pgTable("slides", {
   packageWinePositionIdx: index("idx_slides_package_wine_position").on(table.packageWineId, table.position),
   globalPositionIdx: index("idx_slides_global_position").on(table.packageWineId, table.globalPosition),
   packageWineIdx: index("idx_slides_package_wine_id").on(table.packageWineId),
-  packageIdIdx: index("idx_slides_package_id").on(table.packageId)
+  packageIdIdx: index("idx_slides_package_id").on(table.packageId),
+  typeIdx: index("idx_slides_type").on(table.type)
 }));
 
 // Sessions table
@@ -171,7 +172,8 @@ export const participants = pgTable("participants", {
   sommelier_feedback: text("sommelier_feedback"),
 }, (table) => ({
   sessionIdx: index("idx_participants_session").on(table.sessionId),
-  emailSessionIdx: index("idx_participants_email_session").on(table.email, table.sessionId)
+  emailSessionIdx: index("idx_participants_email_session").on(table.email, table.sessionId),
+  emailIdx: index("idx_participants_email").on(table.email)
 }));
 
 // Responses table
@@ -657,6 +659,7 @@ export const users = pgTable("users", {
   // Onboarding quiz
   onboardingCompleted: boolean("onboarding_completed").default(false).notNull(),
   onboardingData: jsonb("onboarding_data"), // OnboardingData blob
+  lastSeenAt: timestamp("last_seen_at"),
 }, (table) => ({
   emailIdx: index("idx_users_email").on(table.email)
 }));


### PR DESCRIPTION
## Summary
- Integrates group tasting responses into the taste profile synthesis pipeline so group-only users get real trait bars, style identity, and recommendations
- Fixes broken `getGroupTastingPreferences` which was querying non-existent JSONB fields
- Handles production data shape mismatches: bare number `answer_json`, mixed `scale_max`/`scaleMax` casing, null `category` with title-based fallback extraction
- Updates frontend empty states for group-only users with contextual messaging
- Adds database indexes on `participants.email` and `slides.type` for query performance

## Test plan
- [x] Verified group-only user (violamgx@gmail.com) now sees real trait values in `/api/dashboard/:email/preferences`
- [x] Verified taste profile synthesis produces traits, style identity, and GPT output for group-only users
- [x] Verified no regression for solo users (andres@audos.com)
- [x] Verified frontend shows Taste Profile card with group data on HomeV2 Solo and Dashboard tabs
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)